### PR TITLE
Make log level configurable via environment variable

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -12,13 +12,11 @@ RUN apt-get -y update && /sbin/enable-service ssl-kit \
 	&& LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes --no-install-recommends slapd ldap-utils \
 	&& rm -rf /var/lib/ldap
 
-# Add install script and OpenLDAP assets
-ADD service/install.sh /tmp/install.sh
+# Add OpenLDAP assets
 ADD service/slapd/assets /osixia/slapd
 
-# Run install script and clean all
-RUN ./tmp/install.sh \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Clean all
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add default env variables
 ADD env.yml /etc/env.yml

--- a/image/env.yml
+++ b/image/env.yml
@@ -1,6 +1,7 @@
 LDAP_ORGANISATION: Example Inc.
 LDAP_DOMAIN: example.org
 LDAP_ADMIN_PASSWORD: admin
+LDAP_LOG_LEVEL: -1
 
 SERVER_NAME: ldap.example.org
 

--- a/image/service/install.sh
+++ b/image/service/install.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -e
-# this script is run during the image build
-
-# Enable access only from docker default network and localhost
-echo "slapd: 172.17.0.0/255.255.0.0 127.0.0.1 : ALLOW" >> /etc/hosts.allow
-echo "slapd: ALL : DENY" >> /etc/hosts.allow

--- a/image/service/slapd/daemon.sh
+++ b/image/service/slapd/daemon.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -e
-exec /usr/sbin/slapd -h "ldap:/// ldapi:///" -u openldap -g openldap -d -1
+exec /usr/sbin/slapd -h "ldap:/// ldapi:///" -u openldap -g openldap -d "$LDAP_LOG_LEVEL"


### PR DESCRIPTION
Currently, the slapd log level is hardcoded to -1 (= all) in daemon.sh. While this is useful for debugging, it should be possible to trim down the amount of logging for production use.

This change allows the log level to be set via the environment LDAP_LOG_LEVEL.

(See table 5.1 in http://www.openldap.org/doc/admin24/slapdconf2.html for the available log levels.)