### PR TITLE
Limit max open file descriptors to fix slapd memory usage

### DIFF
--- a/image/service/slapd/container-start.sh
+++ b/image/service/slapd/container-start.sh
@@ -2,6 +2,11 @@
 
 FIRST_START_DONE="/etc/docker-openldap-first-start-done"
 
+# Reduce maximum number of number of open file descriptors to 1024
+# otherwise slapd consumes two orders of magnitude more of RAM
+# see https://github.com/docker/docker/issues/8231
+ulimit -n 1024
+
 #fix file permissions
 chown -R openldap:openldap /var/lib/ldap 
 chown -R openldap:openldap /etc/ldap

--- a/image/service/slapd/daemon.sh
+++ b/image/service/slapd/daemon.sh
@@ -1,2 +1,8 @@
 #!/bin/bash -e
+
+# Reduce maximum number of number of open file descriptors to 1024
+# otherwise slapd consumes two orders of magnitude more of RAM
+# see https://github.com/docker/docker/issues/8231
+ulimit -n 1024
+
 exec /usr/sbin/slapd -h "ldap:/// ldapi:///" -u openldap -g openldap -d "$LDAP_LOG_LEVEL"


### PR DESCRIPTION
See https://github.com/docker/docker/issues/8231.