### PR TITLE
Substitutes Base DN in custom ldif files

### DIFF
--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -192,6 +192,7 @@ EOF
     log-helper info "Add bootstrap ldif..."
     for f in $(find ${CONTAINER_SERVICE_DIR}/slapd/assets/config/bootstrap/ldif -mindepth 1 -maxdepth 1 -type f -name \*.ldif  | sort); do
       log-helper debug "Processing file ${f}"
+      sed -i "s|{{ LDAP_BASE_DN }}|${LDAP_BASE_DN}|g" $f
       ldapmodify -Y EXTERNAL -Q -H ldapi:/// -f $f 2>&1 | log-helper debug || ldapmodify -h localhost -p 389 -D cn=admin,$LDAP_BASE_DN -w $LDAP_ADMIN_PASSWORD -f $f 2>&1 | log-helper debug
     done
 


### PR DESCRIPTION
This is a minor change but it helps a lot when the image is used for ldap integration testing and users are created using ldifs.