### PR TITLE
Use mdb over hdb

### DIFF
--- a/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
@@ -1,4 +1,4 @@
-dn: olcDatabase={1}hdb,cn=config
+dn: olcDatabase={1}mdb,cn=config
 changetype: modify
 delete: olcAccess
 -

--- a/image/service/slapd/assets/config/bootstrap/ldif/03-memberOf.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/03-memberOf.ldif
@@ -5,7 +5,7 @@ add: olcModuleLoad
 olcModuleLoad: memberof
 
 # Backend memberOf overlay
-dn: olcOverlay={0}memberof,olcDatabase={1}hdb,cn=config
+dn: olcOverlay={0}memberof,olcDatabase={1}mdb,cn=config
 changetype: add
 objectClass: olcOverlayConfig
 objectClass: olcMemberOf

--- a/image/service/slapd/assets/config/bootstrap/ldif/04-refint.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/04-refint.ldif
@@ -5,7 +5,7 @@ add: olcModuleLoad
 olcModuleLoad: refint
 
 # Backend refint overlay
-dn: olcOverlay={1}refint,olcDatabase={1}hdb,cn=config
+dn: olcOverlay={1}refint,olcDatabase={1}mdb,cn=config
 changetype: add
 objectClass: olcOverlayConfig
 objectClass: olcRefintConfig

--- a/image/service/slapd/assets/config/bootstrap/ldif/05-index.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/05-index.ldif
@@ -1,5 +1,5 @@
 # Add indexes
-dn: olcDatabase={1}hdb,cn=config
+dn: olcDatabase={1}mdb,cn=config
 changetype:  modify
 replace: olcDbIndex
 olcDbIndex: uid eq

--- a/image/service/slapd/assets/config/bootstrap/ldif/readonly-user/readonly-user-acl.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/readonly-user/readonly-user-acl.ldif
@@ -1,4 +1,4 @@
-dn: olcDatabase={1}hdb,cn=config
+dn: olcDatabase={1}mdb,cn=config
 changetype: modify
 delete: olcAccess
 -

--- a/image/service/slapd/assets/config/replication/replication-disable.ldif
+++ b/image/service/slapd/assets/config/replication/replication-disable.ldif
@@ -1,12 +1,12 @@
-# Delete sync replication on hdb
-dn: olcDatabase={1}hdb,cn=config
+# Delete sync replication on mdb
+dn: olcDatabase={1}mdb,cn=config
 changetype: modify
 delete: olcSyncRepl
 -
 delete: olcMirrorMode
 
-# Delete syncprov on hdb
-dn: olcOverlay=syncprov,olcDatabase={1}hdb,cn=config
+# Delete syncprov on mdb
+dn: olcOverlay=syncprov,olcDatabase={1}mdb,cn=config
 changetype: delete
 
 # Delete sync replication on config

--- a/image/service/slapd/assets/config/replication/replication-enable.ldif
+++ b/image/service/slapd/assets/config/replication/replication-enable.ldif
@@ -26,15 +26,15 @@ add: olcSyncRepl
 add: olcMirrorMode
 olcMirrorMode: TRUE
 
-# Add syncprov on hdb
-dn: olcOverlay=syncprov,olcDatabase={1}hdb,cn=config
+# Add syncprov on mdb
+dn: olcOverlay=syncprov,olcDatabase={1}mdb,cn=config
 changetype: add
 objectClass: olcOverlayConfig
 objectClass: olcSyncProvConfig
 olcOverlay: syncprov
 
-# Add sync replication on hdb
-dn: olcDatabase={1}hdb,cn=config
+# Add sync replication on mdb
+dn: olcDatabase={1}mdb,cn=config
 changetype: modify
 add: olcSyncRepl
 {{ LDAP_REPLICATION_HOSTS_HDB_SYNC_REPL }}

--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -66,6 +66,7 @@ if [ ! -e "$FIRST_START_DONE" ]; then
     log-helper info "Database and config directory are empty..."
     log-helper info "Init new ldap server..."
 
+    # Use mdb : http://www.openldap.org/doc/admin24/backends.html
     cat <<EOF | debconf-set-selections
 slapd slapd/internal/generated_adminpw password ${LDAP_ADMIN_PASSWORD}
 slapd slapd/internal/adminpw password ${LDAP_ADMIN_PASSWORD}
@@ -74,7 +75,7 @@ slapd slapd/password1 password ${LDAP_ADMIN_PASSWORD}
 slapd slapd/dump_database_destdir string /var/backups/slapd-VERSION
 slapd slapd/domain string ${LDAP_DOMAIN}
 slapd shared/organization string ${LDAP_ORGANISATION}
-slapd slapd/backend string HDB
+slapd slapd/backend string MDB
 slapd slapd/purge_database boolean true
 slapd slapd/move_old_database boolean true
 slapd slapd/allow_ldap_v2 boolean false


### PR DESCRIPTION
«The mdb backend to slapd(8) is the recommended primary backend for a
normal slapd database. It uses OpenLDAP's own Lightning Memory-Mapped
Database (LMDB) library to store data and is intended to replace the
Berkeley DB backends.

It supports indexing like the BDB backends, but it uses no caching and
requires no tuning to deliver maximum search performance. Like hdb, it
is also fully hierarchical and supports subtree renames in constant
time.»
http://www.openldap.org/doc/admin24/backends.html