### PR TITLE
Remove Volume command from Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/.twgit_features_subject
-/.twgit
+/.*
+!/.git*

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ By default the admin has the password **admin**. All those default settings can 
 
 #### Data persistence
 
-The directories `/var/lib/ldap` (LDAP database files) and `/etc/ldap/slapd.d`  (LDAP config files) has been declared as volumes, so your ldap files are saved outside the container in data volumes.
+The directories `/var/lib/ldap` (LDAP database files) and `/etc/ldap/slapd.d`  (LDAP config files) are used to persist the schema and data information, and should be mapped as volumes, so your ldap files are saved outside the container (see [Use an existing ldap database](#use-an-existing-ldap-database)). However it can be useful to not use volumes,
+in case the image should be delivered complete with test data - this is especially useful when deriving other images from this one.
 
 For more information about docker data volume, please refer to:
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -28,8 +28,5 @@ RUN /container/tool/install-service
 # Add default env variables
 ADD environment /container/environment/99-default
 
-# Set OpenLDAP data and config directories in a data volume
-VOLUME ["/var/lib/ldap", "/etc/ldap/slapd.d"]
-
 # Expose default ldap and ldaps ports
 EXPOSE 389 636


### PR DESCRIPTION
I came to a situation, where i wanted to use this docker image as a base image for a project specific one with prepared test data in one case, and with a persistent data storage using volumes in another. Alas, since the LDAP storage directories are declared as volumes in the Dockerfile, it is not easily possible to deliver an image with volatile test data.

Since it is not possible to remove the volume command from a base image, I had to create a private branch of your repository, and apply my change. I think it would be beneficial for all users to drop the Volume command from the Dockerfile, as it does not forbid using volumes, but it forbids not using volumes.

See [https://github.com/docker/docker/pull/8177] for a discussion of removing volumes from base images.