### PR TITLE
Make BATS testing not affect base test data, allowing easier CI integration

### DIFF
--- a/image/service/slapd/test.sh
+++ b/image/service/slapd/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+# Copy testing data to their respective directories on an as-needed basis
+mkdir -p /var/lib/ldap
+mkdir -p /etc/ldap/slapd.d
+cp -rf /container/test/database/* /var/lib/ldap/ || true
+cp -rf /container/test/config/* /etc/ldap/slapd.d/ || true

--- a/test/test.bats
+++ b/test/test.bats
@@ -37,8 +37,6 @@ load test_helper
   run docker exec $CONTAINER_ID ldapsearch -x -h ldap.osixia.net -b dc=example,dc=org -ZZ -D "cn=admin,dc=example,dc=org" -w admin
   clear_container
 
-  chmod 777 -R test/config/ test/database/
-
   [ "$status" -eq 0 ]
 
 }
@@ -49,8 +47,6 @@ load test_helper
   wait_process slapd
   run docker exec $CONTAINER_ID ldapsearch -x -h ldap.example.org -b dc=osixia,dc=net -D "cn=admin,dc=osixia,dc=net" -w admin
   clear_container
-
-  chmod 777 -R test/config/ test/database/
 
   [ "$status" -eq 0 ]
 

--- a/test/test.bats
+++ b/test/test.bats
@@ -45,7 +45,7 @@ load test_helper
 
 @test "ldapsearch existing database and config" {
 
-  run_image -h ldap.example.org -e LDAP_TLS=false -v $BATS_TEST_DIRNAME/database:/var/lib/ldap -v $BATS_TEST_DIRNAME/config:/etc/ldap/slapd.d
+  run_image -h ldap.example.org -e LDAP_TLS=false -v $BATS_TEST_DIRNAME/database:/container/test/database -v $BATS_TEST_DIRNAME/config:/container/test/config
   wait_process slapd
   run docker exec $CONTAINER_ID ldapsearch -x -h ldap.example.org -b dc=osixia,dc=net -D "cn=admin,dc=osixia,dc=net" -w admin
   clear_container

--- a/test/test.bats
+++ b/test/test.bats
@@ -32,12 +32,12 @@ load test_helper
 
 @test "ldapsearch new database with strict TLS and custom ca/crt" {
 
-  run_image -h ldap.osixia.net -v $BATS_TEST_DIRNAME/ssl:/container/service/slapd/assets/certs -e LDAP_TLS_CRT_FILENAME=ldap-test.crt -e LDAP_TLS_KEY_FILENAME=ldap-test.key -e LDAP_TLS_CA_CRT_FILENAME=ca-test.crt
+  run_image -h ldap.osixia.net -v $BATS_TEST_DIRNAME/ssl:/container/run/service/slapd/assets/certs -e LDAP_TLS_CRT_FILENAME=ldap-test.crt -e LDAP_TLS_KEY_FILENAME=ldap-test.key -e LDAP_TLS_CA_CRT_FILENAME=ca-test.crt
   wait_process slapd
   run docker exec $CONTAINER_ID ldapsearch -x -h ldap.osixia.net -b dc=example,dc=org -ZZ -D "cn=admin,dc=example,dc=org" -w admin
   clear_container
 
-  chmod 777 -R test/config/ test/database/ test/ssl/
+  chmod 777 -R test/config/ test/database/
 
   [ "$status" -eq 0 ]
 
@@ -50,7 +50,7 @@ load test_helper
   run docker exec $CONTAINER_ID ldapsearch -x -h ldap.example.org -b dc=osixia,dc=net -D "cn=admin,dc=osixia,dc=net" -w admin
   clear_container
 
-  chmod 777 -R test/config/ test/database/ test/ssl/
+  chmod 777 -R test/config/ test/database/
 
   [ "$status" -eq 0 ]
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -9,7 +9,7 @@ build_image() {
 }
 
 run_image() {
-  CONTAINER_ID=$(docker run $@ -d $IMAGE_NAME)
+  CONTAINER_ID=$(docker run $@ -d $IMAGE_NAME --copy-service)
   CONTAINER_IP=$(get_container_ip_by_cid $CONTAINER_ID)
 }
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -9,7 +9,7 @@ build_image() {
 }
 
 run_image() {
-  CONTAINER_ID=$(docker run $@ -d $IMAGE_NAME --copy-service)
+  CONTAINER_ID=$(docker run $@ -d $IMAGE_NAME --copy-service -c "/container/service/slapd/test.sh")
   CONTAINER_IP=$(get_container_ip_by_cid $CONTAINER_ID)
 }
 


### PR DESCRIPTION
Fixes issue #90 

Test data in test/{ssl,config,database} were previously affected by running tests, especially by in-container scripts changing permissions/owner. This could lead to problems in a CI environment, such as files changing ownership and being unable to be automatically removed. 

ssl certificates are now copied by --copy-service and refered to via /container/run,
and database/config are mapped to /container/test instead which can be copied to the right place by calling test.sh script bundled in image (via --cmd runtime option)

Note that this does not affect actual resulting container image save for the addition of test.sh which is unused unless explicitly called via --cmd