### PR TITLE
README.md - change deprecated '-h' to now favoured '-H ldap://'

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Run OpenLDAP docker image:
 
 This start a new container with OpenLDAP running inside. Let's make the first search in our LDAP container:
 
-	docker exec my-openldap-container ldapsearch -x -h localhost -b dc=example,dc=org -D "cn=admin,dc=example,dc=org" -w admin
+	docker exec my-openldap-container ldapsearch -x -H ldap://localhost -b dc=example,dc=org -D "cn=admin,dc=example,dc=org" -w admin
 
 This should output:
 
@@ -177,11 +177,11 @@ That's it! But a little test to be sure:
 
 Add a new user "billy" on the first ldap server
 
-	docker exec $LDAP_CID ldapadd -x -D "cn=admin,dc=example,dc=org" -w admin -f /container/service/slapd/assets/test/new-user.ldif -h ldap.example.org -ZZ
+	docker exec $LDAP_CID ldapadd -x -D "cn=admin,dc=example,dc=org" -w admin -f /container/service/slapd/assets/test/new-user.ldif -H ldap://ldap.example.org -ZZ
 
 Search on the second ldap server, and billy should show up!
 
-	docker exec $LDAP2_CID ldapsearch -x -h ldap2.example.org -b dc=example,dc=org -D "cn=admin,dc=example,dc=org" -w admin -ZZ
+	docker exec $LDAP2_CID ldapsearch -x -H ldap://ldap2.example.org -b dc=example,dc=org -D "cn=admin,dc=example,dc=org" -w admin -ZZ
 
 	[...]
 


### PR DESCRIPTION
According to new stable man:
http://www.openldap.org/software/man.cgi?query=ldapsearch&apropos=0&sektion=0&manpath=OpenLDAP+2.4-Release&format=html

>        -H ldapuri
>               Specify URI(s) referring to the ldap server(s); a list  of  URI,
>               separated   by  whitespace  or  commas  is  expected;  only  the
>               protocol/host/port fields are allowed.  As an exception,  if  no
>               host/port  is  specified, but a DN is, the DN is used to look up
>               the corresponding host(s) using the DNS SRV  records,  according
>               to  RFC 2782.  The DN must be a non-empty sequence of AVAs whose
>               attribute type is "dc" (domain component), and must  be  escaped
>               according to RFC 2396.
> 
>        -h ldaphost
>               Specify  an  alternate host on which the ldap server is running.
>               Deprecated in favor of -H.
> 
>        -p ldapport
>               Specify  an  alternate  TCP  port  where  the  ldap  server   is
>               listening.  Deprecated in favor of -H.