### PR TITLE
Add "watch directory" feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Other environment variables:
 
 - **LDAP_REMOVE_CONFIG_AFTER_SETUP**: delete config folder after setup. Defaults to `true`
 - **LDAP_SSL_HELPER_PREFIX**: ssl-helper environment variables prefix. Defaults to `ldap`, ssl-helper first search config from LDAP_SSL_HELPER_* variables, before SSL_HELPER_* variables.
+- **MONITOR_DIR**: monitor a directory for changes and kill slapd.  Defaults to nothing.  This is useful to restart on config changes.
 
 
 ### Set your own environment variables

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get -y update \
        libsasl2-modules-otp \
        libsasl2-modules-sql \
        openssl \
+       inotify-tools \
        slapd \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/image/service/slapd/process.sh
+++ b/image/service/slapd/process.sh
@@ -9,4 +9,8 @@ log-helper level eq trace && set -x
 # see https://github.com/docker/docker/issues/8231
 ulimit -n 1024
 
+if [[ ${MONITOR_DIR} != "" ]]; then
+	sh -c 'inotifywait -e modify -e attrib -e move -e create -e delete -e delete_self -e unmount -r ${MONITOR_DIR}; killall slapd' &
+fi
+
 exec /usr/sbin/slapd -h "ldap://$HOSTNAME ldaps://$HOSTNAME ldapi:///" -u openldap -g openldap -d $LDAP_LOG_LEVEL


### PR DESCRIPTION
This is mostly for a kubernetes setup where you might have your config in a configmap.
We're actually using this for a semi-stateless LDAP server based on our google apps users, which will update the configmaps containing the users, this param allows the container to die, which then Kubernetes will then restart.
A neater solution would be to reload config and keep running, but in our case, our init container would then not run it's preparatory tasks.