### PR TITLE
Enable matching uid's and gid's in the host and container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ By default the admin has the password **admin**. All those default settings can 
 The directories `/var/lib/ldap` (LDAP database files) and `/etc/ldap/slapd.d`  (LDAP config files) are used to persist the schema and data information, and should be mapped as volumes, so your ldap files are saved outside the container (see [Use an existing ldap database](#use-an-existing-ldap-database)). However it can be useful to not use volumes,
 in case the image should be delivered complete with test data - this is especially useful when deriving other images from this one.
 
+The default uid and gid used by the image may map to surprising
+counterparts in the host. If you need to match uid and gid in the
+container and in the host, you can use build parameters
+`LDAP_OPENLDAP_UID` and `LDAP_OPENLDAP_GID` to set uid and gid
+explicitly:
+
+	docker build --build-arg LDAP_OPENLDAP_GID=1234 --build-arg LDAP_OPENLDAP_UID=2345 -t my_ldap_image .
+	docker run --name my_ldap_container -d my_ldap_image
+	# this should output uid=2345(openldap) gid=1234(openldap) groups=1234(openldap)
+	docker exec my_ldap_container id openldap
+
 For more information about docker data volume, please refer to:
 
 > [https://docs.docker.com/engine/tutorials/dockervolumes/](https://docs.docker.com/engine/tutorials/dockervolumes/)

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -3,8 +3,13 @@
 FROM osixia/light-baseimage:1.1.0
 MAINTAINER Bertrand Gouny <bertrand.gouny@osixia.net>
 
+ARG LDAP_OPENLDAP_GID
+ARG LDAP_OPENLDAP_UID
+
 # Add openldap user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r openldap && useradd -r -g openldap openldap
+# If explicit uid or gid is given, use it.
+RUN if [ -z "${LDAP_OPENLDAP_GID}" ]; then groupadd -r openldap; else groupadd -r -g ${LDAP_OPENLDAP_GID} openldap; fi \
+    && if [ -z "${LDAP_OPENLDAP_UID}" ]; then useradd -r -g openldap openldap; else useradd -r -g openldap -u ${LDAP_OPENLDAP_UID} openldap; fi
 
 # Install OpenLDAP, ldap-utils and ssl-tools from baseimage and clean apt-get files
 # sources: https://github.com/osixia/docker-light-baseimage/blob/stable/image/tool/add-service-available


### PR DESCRIPTION
I am using the image in a setup where we are required to use specific uid and gid for the ldap database. This pull request adds the capability to do so.

Build parameters LDAP_OPENLDAP_UID and LDAP_OPENLDAP_GID can be used
to set the uid and gid of the openldap user explicitly.