### PR TITLE
Create schemas in a consistent order.

### DIFF
--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -214,7 +214,7 @@ EOF
       ${CONTAINER_SERVICE_DIR}/slapd/assets/schema-to-ldif.sh "$SCHEMAS"
 
       # add converted schemas
-      for f in $(find ${CONTAINER_SERVICE_DIR}/slapd/assets/config/bootstrap/schema -name \*.ldif -type f); do
+      for f in $(find ${CONTAINER_SERVICE_DIR}/slapd/assets/config/bootstrap/schema -name \*.ldif -type f|sort); do
         log-helper debug "Processing file ${f}"
         # add schema if not already exists
         SCHEMA=$(basename "${f}" .ldif)


### PR DESCRIPTION
@BertrandGouny that should do it, would be great if someone could double check it (init a new server and check that the schema is generated in alphabetical order).

Btw would you accept and env var to disable the default mmc schemas?