### PR TITLE
startup.sh: Ensure SCHEMAS is sorted

### DIFF
--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -214,7 +214,7 @@ EOF
 
       # convert schemas to ldif
       SCHEMAS=""
-      for f in $(find ${CONTAINER_SERVICE_DIR}/slapd/assets/config/bootstrap/schema -name \*.schema -type f); do
+      for f in $(find ${CONTAINER_SERVICE_DIR}/slapd/assets/config/bootstrap/schema -name \*.schema -type f|sort); do
         SCHEMAS="$SCHEMAS ${f}"
       done
       ${CONTAINER_SERVICE_DIR}/slapd/assets/schema-to-ldif.sh "$SCHEMAS"


### PR DESCRIPTION
`find` doesn't sort the output, but if you don't sort it and two schema files are dependent on each other (schema 2 uses an attribute defined in schema 1) the startup of the container will fail if `find` doesn't happen to return in the order needed. By sorting it you can know/rely on asciibetical sorting to ensure the schema files get included in the right order.

Also, this isn't needed if instead of `find` you use `for f in /path/to/*.schema` as the glob already returns in asciibetical order. Makes for one less call to a binary too.