### PR TITLE
Add SASL db auth support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.2.0] - Unreleased
+## [1.2.0] - 2018-03-02
 ### Changed
   - Use mdb as default backend
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -16,7 +16,7 @@ RUN if [ -z "${LDAP_OPENLDAP_GID}" ]; then groupadd -r openldap; else groupadd -
 #          https://github.com/osixia/docker-light-baseimage/blob/stable/image/service-available/:ssl-tools/download.sh
 RUN echo "path-include /usr/share/doc/krb5*" >> /etc/dpkg/dpkg.cfg.d/docker && apt-get -y update \
     && /container/tool/add-service-available :ssl-tools \
-	  && LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      && LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        ldap-utils \
        libsasl2-modules \
        libsasl2-modules-db \
@@ -27,6 +27,7 @@ RUN echo "path-include /usr/share/doc/krb5*" >> /etc/dpkg/dpkg.cfg.d/docker && a
        openssl \
        slapd \
        krb5-kdc-ldap \
+       sasl2-bin \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
@@ -5,3 +5,18 @@ delete: olcAccess
 add: olcAccess
 olcAccess: to attrs=userPassword,shadowLastChange by self write by dn="cn=admin,{{ LDAP_BASE_DN }}" write by anonymous auth by * none
 olcAccess: to * by self write by dn="cn=admin,{{ LDAP_BASE_DN }}" write by * none
+
+dn: cn=config
+changetype: modify
+replace: olcAuthzRegexp
+olcAuthzRegexp: uid=([^,]+),.* cn=$1,dc=example,dc=org
+-
+replace: olcSaslAuxprops
+olcSaslAuxprops: sasldb
+-
+replace: olcSaslRealm
+olcSaslRealm: example.org
+-
+replace: olcSaslHost
+olcSaslHost: example.org
+-

--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -21,7 +21,7 @@ chown -R openldap:openldap ${CONTAINER_SERVICE_DIR}/slapd
 chown openldap:openldap /etc/sasldb2
 
 # add sasldb credentials
-echo -n "$LDAP_ADMIN_PASSWORD" | saslpasswd2 -p -u example.org -c admin
+echo -n "$LDAP_ADMIN_PASSWORD" | saslpasswd2 -p -u "$LDAP_DOMAIN" -c admin
 
 FIRST_START_DONE="${CONTAINER_STATE_DIR}/slapd-first-start-done"
 WAS_STARTED_WITH_TLS="/etc/ldap/slapd.d/docker-openldap-was-started-with-tls"

--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -18,6 +18,10 @@ ulimit -n 1024
 chown -R openldap:openldap /var/lib/ldap
 chown -R openldap:openldap /etc/ldap
 chown -R openldap:openldap ${CONTAINER_SERVICE_DIR}/slapd
+chown openldap:openldap /etc/sasldb2
+
+# add sasldb credentials
+echo -n "$LDAP_ADMIN_PASSWORD" | saslpasswd2 -p -u example.org -c admin
 
 FIRST_START_DONE="${CONTAINER_STATE_DIR}/slapd-first-start-done"
 WAS_STARTED_WITH_TLS="/etc/ldap/slapd.d/docker-openldap-was-started-with-tls"


### PR DESCRIPTION
This enables the use of the DIGEST-MD5 mechanism (and others) which is the SASL mech suggested as a minimum by the LDAP specs.

I have tested to ensure the EXTERNAL mech still works after these changes.