### PR TITLE
Fixes #172. LDAP_BASE_DN env was not used for the actual LDAP base

### DIFF
--- a/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
@@ -5,3 +5,13 @@ delete: olcAccess
 add: olcAccess
 olcAccess: to attrs=userPassword,shadowLastChange by self write by dn="cn=admin,{{ LDAP_BASE_DN }}" write by anonymous auth by * none
 olcAccess: to * by self read by dn="cn=admin,{{ LDAP_BASE_DN }}" write by * none
+-
+delete: olcSuffix
+-
+add: olcSuffix
+olcSuffix: {{ LDAP_BASE_DN }}
+-
+delete: olcRootDN
+-
+add: olcRootDN
+olcRootDN: cn=admin,{{ LDAP_BASE_DN }}

--- a/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
@@ -6,12 +6,8 @@ add: olcAccess
 olcAccess: to attrs=userPassword,shadowLastChange by self write by dn="cn=admin,{{ LDAP_BASE_DN }}" write by anonymous auth by * none
 olcAccess: to * by self read by dn="cn=admin,{{ LDAP_BASE_DN }}" write by * none
 -
-delete: olcSuffix
--
-add: olcSuffix
+replace: olcSuffix
 olcSuffix: {{ LDAP_BASE_DN }}
 -
-delete: olcRootDN
--
-add: olcRootDN
+replace: olcRootDN
 olcRootDN: cn=admin,{{ LDAP_BASE_DN }}

--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -72,9 +72,9 @@ if [ ! -e "$FIRST_START_DONE" ]; then
       sed -i "s|{{ LDAP_READONLY_USER_PASSWORD_ENCRYPTED }}|${LDAP_READONLY_USER_PASSWORD_ENCRYPTED}|g" $LDIF_FILE
     fi
     if grep -iq changetype $LDIF_FILE ; then
-        ldapmodify -Y EXTERNAL -Q -H ldapi:/// -f $LDIF_FILE 2>&1 | log-helper debug || ldapmodify -h localhost -p 389 -D cn=admin,$LDAP_BASE_DN -w "$LDAP_ADMIN_PASSWORD" -f $LDIF_FILE 2>&1 | log-helper debug
+        ldapmodify -Y EXTERNAL -Q -H ldapi:/// -f $LDIF_FILE 2>&1 | log-helper debug || ldapmodify -h localhost -p 389 -D "cn=admin,$LDAP_BASE_DN" -w "$LDAP_ADMIN_PASSWORD" -f $LDIF_FILE 2>&1 | log-helper debug
     else
-        ldapadd -Y EXTERNAL -Q -H ldapi:/// -f $LDIF_FILE |& log-helper debug || ldapadd -h localhost -p 389 -D cn=admin,$LDAP_BASE_DN -w "$LDAP_ADMIN_PASSWORD" -f $LDIF_FILE 2>&1 | log-helper debug
+        ldapadd -Y EXTERNAL -Q -H ldapi:/// -f $LDIF_FILE |& log-helper debug || ldapadd -h localhost -p 389 -D "cn=admin,$LDAP_BASE_DN" -w "$LDAP_ADMIN_PASSWORD" -f $LDIF_FILE 2>&1 | log-helper debug
     fi
   }
 


### PR DESCRIPTION
When environmentvariables have been set like this:
      LDAP_BASE_DN="o=some org,c=com"
      LDAP_DOMAIN="some-org.com"

The base dn of the generated LDAP is dc=some-org,dc=com instead of o=some org,c=com

This commit fixes that.

It might be better to move the change to a file different from 02-security.ldif or maybe renaming it as this might be confusing otherwise.