### PR TITLE
Fix self-edit security issue

### DIFF
--- a/image/service/slapd/assets/config/bootstrap/ldif/readonly-user/readonly-user-acl.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/readonly-user/readonly-user-acl.ldif
@@ -4,4 +4,4 @@ delete: olcAccess
 -
 add: olcAccess
 olcAccess: to attrs=userPassword,shadowLastChange by self write by dn="cn=admin,{{ LDAP_BASE_DN }}" write by anonymous auth by * none
-olcAccess: to * by self write by dn="cn=admin,{{ LDAP_BASE_DN }}" write by dn="cn={{ LDAP_READONLY_USER_USERNAME }},{{ LDAP_BASE_DN }}" read by * none
+olcAccess: to * by self read by dn="cn=admin,{{ LDAP_BASE_DN }}" write by dn="cn={{ LDAP_READONLY_USER_USERNAME }},{{ LDAP_BASE_DN }}" read by * none


### PR DESCRIPTION
The security issue fixed in version 1.2.1 is still there when a read-only user is created.