### PR TITLE
Update openldap 2.4.44 (released over two years ago!) to 2.4.46 (released 6 months ago)

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -11,12 +11,15 @@ ARG LDAP_OPENLDAP_UID
 RUN if [ -z "${LDAP_OPENLDAP_GID}" ]; then groupadd -r openldap; else groupadd -r -g ${LDAP_OPENLDAP_GID} openldap; fi \
     && if [ -z "${LDAP_OPENLDAP_UID}" ]; then useradd -r -g openldap openldap; else useradd -r -g openldap -u ${LDAP_OPENLDAP_UID} openldap; fi
 
-# Install OpenLDAP, ldap-utils and ssl-tools from baseimage and clean apt-get files
+# Add stretch-backports in preparation for downloading newer openldap components, especially sladp
+RUN echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list
+
+# Install OpenLDAP, ldap-utils and ssl-tools from the (backported) baseimage and clean apt-get files
 # sources: https://github.com/osixia/docker-light-baseimage/blob/stable/image/tool/add-service-available
 #          https://github.com/osixia/docker-light-baseimage/blob/stable/image/service-available/:ssl-tools/download.sh
 RUN echo "path-include /usr/share/doc/krb5*" >> /etc/dpkg/dpkg.cfg.d/docker && apt-get -y update \
     && /container/tool/add-service-available :ssl-tools \
-	  && LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+	  && LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get -t stretch-backports install -y --no-install-recommends \
        ldap-utils \
        libsasl2-modules \
        libsasl2-modules-db \


### PR DESCRIPTION
Please see [this issue](https://github.com/osixia/docker-openldap/issues/244) for details where Bertrand wrote:
>will be happy to quickly merge any pull request.

The purpose of this pull request is to update from `OpenLDAP 2.4.44 Release` which was released *2 years and 7 months ago* in 2016/02/05 to 2.4.46 which was released 6 months ago.