### PR TITLE
add the ability to seed ldap domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The startup script provides some substitutions in bootstrap ldif files. Followin
 
 - `{{ LDAP_BASE_DN }}`
 - `{{ LDAP_BACKEND }}`
+- `{{ LDAP_DOMAIN }}`
 - `{{ LDAP_READONLY_USER_USERNAME }}`
 - `{{ LDAP_READONLY_USER_PASSWORD_ENCRYPTED }}`
 

--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -67,6 +67,7 @@ if [ ! -e "$FIRST_START_DONE" ]; then
     log-helper debug "Processing file ${LDIF_FILE}"
     sed -i "s|{{ LDAP_BASE_DN }}|${LDAP_BASE_DN}|g" $LDIF_FILE
     sed -i "s|{{ LDAP_BACKEND }}|${LDAP_BACKEND}|g" $LDIF_FILE
+    sed -i "s|{{ LDAP_DOMAIN }}|${LDAP_DOMAIN}|g" $LDIF_FILE
     if [ "${LDAP_READONLY_USER,,}" == "true" ]; then
       sed -i "s|{{ LDAP_READONLY_USER_USERNAME }}|${LDAP_READONLY_USER_USERNAME}|g" $LDIF_FILE
       sed -i "s|{{ LDAP_READONLY_USER_PASSWORD_ENCRYPTED }}|${LDAP_READONLY_USER_PASSWORD_ENCRYPTED}|g" $LDIF_FILE


### PR DESCRIPTION
Hi, 

I recently merged a pr in https://github.com/zokradonh/kopano-docker, but only realised afterwards that {{ LDAP_DOMAIN }} can not be used in seed files. This pr adds this ability. 

fixes https://github.com/zokradonh/kopano-docker/issues/45

Signed-off-by: Felix Bartels <felix@host-consultants.de>