### PR TITLE
Fix invalid DN crash

### DIFF
--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -407,6 +407,8 @@ EOF
       sed -i "s|{{ LDAP_ADMIN_PASSWORD_ENCRYPTED }}|${LDAP_ADMIN_PASSWORD_ENCRYPTED}|g" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/admin-pw/ldif/06-root-pw-change.ldif
       sed -i "s|{{ LDAP_BACKEND }}|${LDAP_BACKEND}|g" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/admin-pw/ldif/06-root-pw-change.ldif
       sed -i "s|{{ LDAP_ADMIN_PASSWORD_ENCRYPTED }}|${LDAP_ADMIN_PASSWORD_ENCRYPTED}|g" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/admin-pw/ldif/07-admin-pw-change.ldif
+
+      get_ldap_base_dn
       sed -i "s|{{ LDAP_BASE_DN }}|${LDAP_BASE_DN}|g" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/admin-pw/ldif/07-admin-pw-change.ldif
 
       for f in $(find ${CONTAINER_SERVICE_DIR}/slapd/assets/config/admin-pw/ldif -type f -name \*.ldif  | sort); do


### PR DESCRIPTION
When relying on `LDAP_BASE_DN` to be derived from `LDAP_DOMAIN`, we crash with invalid dn if `get_ldap_base_dn` is not called before we try to replace the dn in `07-admin-pw-change.ldif`.

This fix calls `get_ldap_base_dn` right before using `LDAP_BASE_DN`, in style with the other places `get_ldap_base_dn` is called.

EDIT: The workaround here is obviously to set `LDAP_BASE_DN` manually, in case anyone else runs into it.