### PR TITLE
Addition of configuration and initialization of a MIT (Kerberos) KDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
-# osixia/openldap
+# Fork of osixia/openldap
+
+This fork is related to [Issue 319: Integrated kerberos KDC configuration](https://github.com/osixia/docker-openldap/issues/319)
+
+Specific changes:
+
+1. Added kerberos.schema
+2. Added kerberos.ldif
+3. Added /etc/krb5.conf
+4. Added /etc/krb5kdc/kdc.conf
+
+.. create ou=users
+.. kdb5_ldap_util cache password
+.. krb5_ldap_util create db
+.. start krb5-kdc
+
 
 ![Docker Pulls](https://img.shields.io/docker/pulls/osixia/openldap.svg)
 ![Docker Stars](https://img.shields.io/docker/stars/osixia/openldap.svg)

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -28,6 +28,7 @@ RUN echo "path-include /usr/share/doc/krb5*" >> /etc/dpkg/dpkg.cfg.d/docker && a
        libsasl2-modules-sql \
        openssl \
        slapd \
+       krb5-admin-server \
        krb5-kdc-ldap \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -44,6 +45,9 @@ ADD environment /container/environment/99-default
 
 # Expose default ldap and ldaps ports
 EXPOSE 389 636
+
+# Expose default kdc and kadmin ports
+EXPOSE 88 750
 
 # Put ldap config and database dir in a volume to persist data.
 # VOLUME /etc/ldap/slapd.d /var/lib/ldap

--- a/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
@@ -3,5 +3,5 @@ changetype: modify
 delete: olcAccess
 -
 add: olcAccess
-olcAccess: to attrs=userPassword,shadowLastChange by self write by dn="cn=admin,{{ LDAP_BASE_DN }}" write by anonymous auth by * none
+olcAccess: to attrs=userPassword,shadowLastChange,krbPrincipalKey by self write by dn="cn=admin,{{ LDAP_BASE_DN }}" write by anonymous auth by * none
 olcAccess: to * by self read by dn="cn=admin,{{ LDAP_BASE_DN }}" write by * none

--- a/image/service/slapd/assets/config/bootstrap/ldif/05-index.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/05-index.ldif
@@ -8,3 +8,4 @@ olcDbIndex: memberOf eq
 olcDbIndex: entryCSN eq
 olcDbIndex: entryUUID eq
 olcDbIndex: objectClass eq
+olcDbIndex: krbPrincipalName eq,pres,sub

--- a/image/service/slapd/assets/config/bootstrap/ldif/custom/01-groups.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/custom/01-groups.ldif
@@ -1,0 +1,32 @@
+dn: ou=users,{{ LDAP_BASE_DN }}
+changetype: add
+objectClass: top
+objectClass: organizationalUnit
+ou:users
+
+dn: ou=services,{{ LDAP_BASE_DN }}
+changetype: add
+objectClass: top
+objectClass: organizationalUnit
+ou:services
+
+#
+# Create temporary entries so we can set ACLs. We could probably
+# skip creating the ou and define them in the same script we use
+# to populate all KDC entries.
+#
+dn: cn=krbContainer,{{ LDAP_BASE_DN }}
+changetype: add
+objectClass: krbContainer
+cn: krbContainer
+
+dn: cn={{ KRB_REALM }},cn=krbContainer,{{ LDAP_BASE_DN }}
+changetype: add
+cn: {{ KRB_REALM }}
+objectClass: top
+objectClass: krbRealmContainer
+objectClass: krbTicketPolicyAux
+krbSubTrees: ou=users,{{ LDAP_BASE_DN }}
+krbSubTrees: ou=services,{{ LDAP_BASE_DN }}
+krbSearchScope: 2
+

--- a/image/service/slapd/assets/config/bootstrap/ldif/custom/02-kdc-security.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/custom/02-kdc-security.ldif
@@ -1,0 +1,16 @@
+#
+# Grant access to principals to kdc_admin/adm_admin if they're outside
+# of the realm container (krbContainer)
+#
+dn: olcDatabase={1}{{ LDAP_BACKEND }},cn=config
+changetype: modify
+add: olcAccess
+olcAccess: to dn.subtree="ou=users,{{ LDAP_BASE_DN }}" by dn.exact="cn={{ KDC_ADMIN }},{{ LDAP_BASE_DN }}" write by dn.exact="cn={{ ADM_ADMIN }},{{ LDAP_BASE_DN }}" write by * none
+olcAccess: to dn.subtree="ou=services,{{ LDAP_BASE_DN }}" by dn.exact="cn={{ KDC_ADMIN }},{{ LDAP_BASE_DN }}" write by dn.exact="cn={{ ADM_ADMIN }},{{ LDAP_BASE_DN }}" write by * none
+
+#
+# Deny access to the realm container to anyone other than kdc_admin/adm_admin
+#
+-
+add: olcAccess
+olcAccess: to dn.subtree="cn={{ KRB_REALM }},cn=krbContainer,{{ LDAP_BASE_DN }} by dn.exact="cn={{ KDC_ADMIN }},{{ LDAP_BASE_DN }}" write by dn.exact="cn={{ ADM_ADMIN }},{{ LDAP_BASE_DN }}" write by * none

--- a/image/service/slapd/assets/config/bootstrap/ldif/custom/03-cleanup.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/custom/03-cleanup.ldif
@@ -1,0 +1,9 @@
+#
+# Delete temporary KDC objects now that we have ACLs set.
+# This allows us to run kdb5-ldap-admin as usual.
+#
+dn: cn={{ KRB_REALM }},cn=krbContainer,{{ LDAP_BASE_DN }}
+changetype: delete
+
+dn: cn=krbContainer,{{ LDAP_BASE_DN }}
+changetype: delete

--- a/image/service/slapd/assets/config/bootstrap/ldif/custom/KERBEROS.md
+++ b/image/service/slapd/assets/config/bootstrap/ldif/custom/KERBEROS.md
@@ -1,0 +1,8 @@
+This directory contains two files that implement a sane default
+KDC configuration. Since 02-kdc-security modifies the LDAP_BACKEND
+it must be run while the LDAP server is down.
+
+The organizationalUnits created, users and services, can be easily
+changed by mounting a docker volume over this directory. Important:
+if you do this you MUST update the script that creates the KDC
+entries as well!

--- a/image/service/slapd/assets/config/bootstrap/schema/mmc/kerberos.schema
+++ b/image/service/slapd/assets/config/bootstrap/schema/mmc/kerberos.schema
@@ -1,0 +1,726 @@
+# Novell Kerberos Schema Definitions
+# Novell Inc.
+# 1800 South Novell Place
+# Provo, UT 84606
+#
+# VeRsIoN=1.0
+# CoPyRiGhT=(c) Copyright 2006, Novell, Inc.  All rights reserved
+#
+# OIDs:
+#    joint-iso-ccitt(2)
+#      country(16)
+#        us(840)
+#          organization(1)
+#            Novell(113719)
+#              applications(1)
+#                kerberos(301)
+#                 Kerberos Attribute Type(4) attr# version#
+#                    specific attribute definitions
+#                 Kerberos Attribute Syntax(5)
+#                    specific syntax definitions
+#                 Kerberos Object Class(6) class# version#
+#                    specific class definitions
+#
+#    iso(1)
+#      member-body(2)
+#        United States(840)
+#          mit (113554)
+#            infosys(1)
+#              ldap(4)
+#                attributeTypes(1)
+#                  Kerberos(6)
+
+########################################################################
+
+
+########################################################################
+#                     Attribute Type Definitions                       #
+########################################################################
+
+##### This is the principal name in the RFC 1964 specified format
+
+attributetype ( 2.16.840.1.113719.1.301.4.1.1
+                NAME 'krbPrincipalName'
+                EQUALITY caseExactIA5Match
+                SUBSTR caseExactSubstringsMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+
+##### If there are multiple krbPrincipalName values for an entry, this
+##### is the canonical principal name in the RFC 1964 specified
+##### format.  (If this attribute does not exist, then all
+##### krbPrincipalName values are treated as canonical.)
+
+attributetype ( 1.2.840.113554.1.4.1.6.1
+                NAME 'krbCanonicalName'
+                EQUALITY caseExactIA5Match
+                SUBSTR caseExactSubstringsMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+                SINGLE-VALUE)
+
+##### This specifies the type of the principal, the types could be any of
+##### the types mentioned in section 6.2 of RFC 4120
+
+attributetype ( 2.16.840.1.113719.1.301.4.3.1
+                NAME 'krbPrincipalType'
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+                SINGLE-VALUE)
+
+
+##### This flag is used to find whether directory User Password has to be used
+##### as kerberos password.
+##### TRUE, if User Password is to be used as the kerberos password.
+##### FALSE, if User Password and the kerberos password are different.
+
+attributetype ( 2.16.840.1.113719.1.301.4.5.1
+                NAME 'krbUPEnabled'
+                DESC 'Boolean'
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+                SINGLE-VALUE)
+
+
+##### The time at which the principal expires
+
+attributetype ( 2.16.840.1.113719.1.301.4.6.1
+                NAME 'krbPrincipalExpiration'
+                EQUALITY generalizedTimeMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+                SINGLE-VALUE)
+
+
+##### The krbTicketFlags attribute holds information about the kerberos flags for a principal
+##### The values (0x00000001 - 0x00800000) are reserved for standards and 
+##### values (0x01000000 - 0x80000000) can be used for proprietary extensions.
+##### The flags and values as per RFC 4120 and MIT implementation are,
+##### DISALLOW_POSTDATED        0x00000001
+##### DISALLOW_FORWARDABLE      0x00000002
+##### DISALLOW_TGT_BASED        0x00000004
+##### DISALLOW_RENEWABLE        0x00000008
+##### DISALLOW_PROXIABLE        0x00000010
+##### DISALLOW_DUP_SKEY         0x00000020
+##### DISALLOW_ALL_TIX          0x00000040
+##### REQUIRES_PRE_AUTH         0x00000080
+##### REQUIRES_HW_AUTH          0x00000100
+##### REQUIRES_PWCHANGE         0x00000200
+##### DISALLOW_SVR              0x00001000
+##### PWCHANGE_SERVICE          0x00002000
+
+
+attributetype ( 2.16.840.1.113719.1.301.4.8.1
+                NAME 'krbTicketFlags'
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+                SINGLE-VALUE)
+
+
+##### The maximum ticket lifetime for a principal in seconds
+
+attributetype ( 2.16.840.1.113719.1.301.4.9.1
+                NAME 'krbMaxTicketLife'
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+                SINGLE-VALUE)
+
+
+##### Maximum renewable lifetime for a principal's ticket in seconds
+
+attributetype ( 2.16.840.1.113719.1.301.4.10.1
+                NAME 'krbMaxRenewableAge'
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+                SINGLE-VALUE)
+
+
+##### Forward reference to the Realm object.
+##### (FDN of the krbRealmContainer object).
+##### Example:   cn=ACME.COM, cn=Kerberos, cn=Security
+
+attributetype ( 2.16.840.1.113719.1.301.4.14.1
+                NAME 'krbRealmReferences'
+                EQUALITY distinguishedNameMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+
+
+##### List of LDAP servers that kerberos servers can contact.
+##### The attribute holds data in the ldap uri format,
+##### Examples: acme.com#636, 164.164.164.164#1636, ldaps://acme.com:636
+#####
+##### The values of this attribute need to be updated, when
+##### the LDAP servers listed here are renamed, moved or deleted.
+
+attributetype ( 2.16.840.1.113719.1.301.4.15.1
+                NAME 'krbLdapServers'
+                EQUALITY caseIgnoreMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.15)
+
+
+##### A set of forward references to the KDC Service objects.
+##### (FDNs of the krbKdcService objects).
+##### Example:   cn=kdc - server 1, ou=uvw, o=xyz
+
+attributetype ( 2.16.840.1.113719.1.301.4.17.1
+                NAME 'krbKdcServers'
+                EQUALITY distinguishedNameMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+
+
+##### A set of forward references to the Password Service objects.
+##### (FDNs of the krbPwdService objects).
+##### Example:   cn=kpasswdd - server 1, ou=uvw, o=xyz
+
+attributetype ( 2.16.840.1.113719.1.301.4.18.1
+                NAME 'krbPwdServers'
+                EQUALITY distinguishedNameMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+
+
+##### This attribute holds the Host Name or the ip address, 
+##### transport protocol and ports of the kerberos service host
+##### The format is host_name-or-ip_address#protocol#port
+##### Protocol can be 0 or 1. 0 is for UDP. 1 is for TCP.
+
+attributetype ( 2.16.840.1.113719.1.301.4.24.1
+                NAME 'krbHostServer'
+                EQUALITY caseExactIA5Match
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+
+
+##### This attribute holds the scope for searching the principals
+##### under krbSubTree attribute of krbRealmContainer
+##### The value can either be 1 (ONE) or 2 (SUB_TREE).
+
+attributetype ( 2.16.840.1.113719.1.301.4.25.1
+                NAME 'krbSearchScope'
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+                SINGLE-VALUE)
+
+
+##### FDNs pointing to Kerberos principals
+
+attributetype ( 2.16.840.1.113719.1.301.4.26.1
+                NAME 'krbPrincipalReferences'
+                EQUALITY distinguishedNameMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+
+
+##### This attribute specifies which attribute of the user objects  
+##### be used as the principal name component for Kerberos.
+##### The allowed values are cn, sn, uid, givenname, fullname.
+
+attributetype ( 2.16.840.1.113719.1.301.4.28.1
+                NAME 'krbPrincNamingAttr'
+                EQUALITY caseIgnoreMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+                SINGLE-VALUE)
+
+
+##### A set of forward references to the Administration Service objects.
+##### (FDNs of the krbAdmService objects).
+##### Example:   cn=kadmindd - server 1, ou=uvw, o=xyz
+
+attributetype ( 2.16.840.1.113719.1.301.4.29.1
+                NAME 'krbAdmServers'
+                EQUALITY distinguishedNameMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+
+
+##### Maximum lifetime of a principal's password
+
+attributetype ( 2.16.840.1.113719.1.301.4.30.1
+                NAME 'krbMaxPwdLife'
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
+                SINGLE-VALUE)
+
+
+##### Minimum lifetime of a principal's password
+
+attributetype ( 2.16.840.1.113719.1.301.4.31.1
+                NAME 'krbMinPwdLife'
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
+                SINGLE-VALUE)
+
+
+##### Minimum number of character clases allowed in a password
+
+attributetype ( 2.16.840.1.113719.1.301.4.32.1
+                NAME 'krbPwdMinDiffChars' 
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
+                SINGLE-VALUE)
+
+
+##### Minimum length of the password
+
+attributetype ( 2.16.840.1.113719.1.301.4.33.1
+                NAME 'krbPwdMinLength' 
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
+                SINGLE-VALUE)
+
+
+##### Number of previous versions of passwords that are stored
+
+attributetype ( 2.16.840.1.113719.1.301.4.34.1
+                NAME 'krbPwdHistoryLength' 
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
+                SINGLE-VALUE)
+
+
+##### Number of consecutive pre-authentication failures before lockout
+
+attributetype ( 1.3.6.1.4.1.5322.21.2.1
+                NAME 'krbPwdMaxFailure' 
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+                SINGLE-VALUE)
+
+
+##### Period after which bad preauthentication count will be reset
+
+attributetype ( 1.3.6.1.4.1.5322.21.2.2
+                NAME 'krbPwdFailureCountInterval' 
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+                SINGLE-VALUE)
+
+
+##### Period in which lockout is enforced
+
+attributetype ( 1.3.6.1.4.1.5322.21.2.3
+                NAME 'krbPwdLockoutDuration' 
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+                SINGLE-VALUE)
+
+
+##### Policy attribute flags
+
+attributetype ( 1.2.840.113554.1.4.1.6.2
+                NAME 'krbPwdAttributes'
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+                SINGLE-VALUE)
+
+
+##### Policy maximum ticket lifetime
+
+attributetype ( 1.2.840.113554.1.4.1.6.3
+                NAME 'krbPwdMaxLife'
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+                SINGLE-VALUE)
+
+
+##### Policy maximum ticket renewable lifetime
+
+attributetype ( 1.2.840.113554.1.4.1.6.4
+                NAME 'krbPwdMaxRenewableLife'
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+                SINGLE-VALUE)
+
+
+##### Allowed enctype:salttype combinations for key changes
+
+attributetype ( 1.2.840.113554.1.4.1.6.5
+                NAME 'krbPwdAllowedKeysalts'
+                EQUALITY caseIgnoreIA5Match
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+                SINGLE-VALUE)
+
+
+##### FDN pointing to a Kerberos Password Policy object
+
+attributetype ( 2.16.840.1.113719.1.301.4.36.1
+                NAME 'krbPwdPolicyReference'
+                EQUALITY distinguishedNameMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+                SINGLE-VALUE)
+
+
+##### The time at which the principal's password expires
+
+attributetype ( 2.16.840.1.113719.1.301.4.37.1
+                NAME 'krbPasswordExpiration'
+                EQUALITY generalizedTimeMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+                SINGLE-VALUE)
+
+
+##### This attribute holds the principal's key (krbPrincipalKey) that is encrypted with
+##### the master key (krbMKey). 
+##### The attribute is ASN.1 encoded.
+#####
+##### The format of the value for this attribute is explained below,
+##### KrbKeySet ::= SEQUENCE {
+##### attribute-major-vno       [0] UInt16,
+##### attribute-minor-vno       [1] UInt16,
+##### kvno                      [2] UInt32,
+##### mkvno                     [3] UInt32 OPTIONAL,
+##### keys                      [4] SEQUENCE OF KrbKey,
+##### ...
+##### }
+#####
+##### KrbKey ::= SEQUENCE {
+##### salt      [0] KrbSalt OPTIONAL,
+##### key       [1] EncryptionKey,
+##### s2kparams [2] OCTET STRING OPTIONAL,
+##### ...
+##### }
+#####
+##### KrbSalt ::= SEQUENCE {
+##### type      [0] Int32,
+##### salt      [1] OCTET STRING OPTIONAL
+##### }
+#####
+##### EncryptionKey ::= SEQUENCE {
+##### keytype   [0] Int32,
+##### keyvalue  [1] OCTET STRING
+##### }
+
+attributetype ( 2.16.840.1.113719.1.301.4.39.1
+                NAME 'krbPrincipalKey'
+                EQUALITY octetStringMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40)
+
+
+##### FDN pointing to a Kerberos Ticket Policy object.
+
+attributetype ( 2.16.840.1.113719.1.301.4.40.1
+                NAME 'krbTicketPolicyReference'
+                EQUALITY distinguishedNameMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+                SINGLE-VALUE)
+
+
+##### Forward reference to an entry that starts sub-trees
+##### where principals and other kerberos objects in the realm are configured.
+##### Example:   ou=acme, ou=pq, o=xyz
+
+attributetype ( 2.16.840.1.113719.1.301.4.41.1
+                NAME 'krbSubTrees'
+                EQUALITY distinguishedNameMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+
+
+##### Holds the default encryption/salt type combinations of principals for
+##### the Realm. Stores in the form of key:salt strings. This will be
+##### subset of the supported encryption/salt types.
+##### Example: des-cbc-crc:normal
+
+attributetype ( 2.16.840.1.113719.1.301.4.42.1
+                NAME 'krbDefaultEncSaltTypes'
+                EQUALITY caseIgnoreMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.15)
+
+
+##### Holds the supported encryption/salt type combinations of principals for
+##### the Realm. Stores in the form of key:salt strings.
+##### The supported encryption types are mentioned in RFC 3961
+##### The supported salt types are,
+##### NORMAL          
+##### V4              
+##### NOREALM         
+##### ONLYREALM       
+##### SPECIAL         
+##### AFS3            
+##### Example: des-cbc-crc:normal
+
+attributetype ( 2.16.840.1.113719.1.301.4.43.1
+                NAME 'krbSupportedEncSaltTypes'
+                EQUALITY caseIgnoreMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.15)
+
+
+##### This attribute holds the principal's old keys (krbPwdHistory) that is encrypted with
+##### the kadmin/history key.
+##### The attribute is ASN.1 encoded.
+#####
+##### The format of the value for this attribute is explained below,
+##### KrbKeySet ::= SEQUENCE {
+##### attribute-major-vno       [0] UInt16,
+##### attribute-minor-vno       [1] UInt16,
+##### kvno                      [2] UInt32,
+##### mkvno                     [3] UInt32 OPTIONAL -- actually kadmin/history key,
+##### keys                      [4] SEQUENCE OF KrbKey,
+##### ...
+##### }
+#####
+##### KrbKey ::= SEQUENCE {
+##### salt      [0] KrbSalt OPTIONAL,
+##### key       [1] EncryptionKey,
+##### s2kparams [2] OCTET STRING OPTIONAL,
+##### ...
+##### }
+#####
+##### KrbSalt ::= SEQUENCE {
+##### type      [0] Int32,
+##### salt      [1] OCTET STRING OPTIONAL
+##### }
+#####
+##### EncryptionKey ::= SEQUENCE {
+##### keytype   [0] Int32,
+##### keyvalue  [1] OCTET STRING
+##### }
+
+attributetype ( 2.16.840.1.113719.1.301.4.44.1
+                NAME 'krbPwdHistory'
+                EQUALITY octetStringMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40)
+
+
+##### The time at which the principal's password last password change happened.
+
+attributetype ( 2.16.840.1.113719.1.301.4.45.1
+                NAME 'krbLastPwdChange'
+                EQUALITY generalizedTimeMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+                SINGLE-VALUE)
+
+##### The time at which the principal was last administratively unlocked.
+
+attributetype ( 1.3.6.1.4.1.5322.21.2.5
+                NAME 'krbLastAdminUnlock'
+                EQUALITY generalizedTimeMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+                SINGLE-VALUE)
+
+##### This attribute holds the kerberos master key.
+##### This can be used to encrypt principal keys. 
+##### This attribute has to be secured in directory.
+#####
+##### This attribute is ASN.1 encoded.
+##### The format of the value for this attribute is explained below,
+##### KrbMKey ::= SEQUENCE {
+##### kvno    [0] UInt32,
+##### key     [1] MasterKey
+##### }
+#####
+##### MasterKey ::= SEQUENCE {
+##### keytype         [0] Int32,
+##### keyvalue        [1] OCTET STRING
+##### }
+
+
+attributetype ( 2.16.840.1.113719.1.301.4.46.1
+                NAME 'krbMKey'
+                EQUALITY octetStringMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40)
+
+
+##### This stores the alternate principal names for the principal in the RFC 1964 specified format
+
+attributetype ( 2.16.840.1.113719.1.301.4.47.1
+                NAME 'krbPrincipalAliases'
+                EQUALITY caseExactIA5Match
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+
+
+##### The time at which the principal's last successful authentication happened.
+
+attributetype ( 2.16.840.1.113719.1.301.4.48.1
+                NAME 'krbLastSuccessfulAuth'
+                EQUALITY generalizedTimeMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+                SINGLE-VALUE)
+
+
+##### The time at which the principal's last failed authentication happened.
+
+attributetype ( 2.16.840.1.113719.1.301.4.49.1
+                NAME 'krbLastFailedAuth'
+                EQUALITY generalizedTimeMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+                SINGLE-VALUE)
+
+
+##### This attribute stores the number of failed authentication attempts
+##### happened for the principal since the last successful authentication.
+
+attributetype ( 2.16.840.1.113719.1.301.4.50.1
+                NAME 'krbLoginFailedCount' 
+                EQUALITY integerMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
+                SINGLE-VALUE)
+
+
+
+##### This attribute holds the application specific data.
+
+attributetype ( 2.16.840.1.113719.1.301.4.51.1
+                NAME 'krbExtraData'
+                EQUALITY octetStringMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40)
+
+
+##### This attributes holds references to the set of directory objects.
+##### This stores the DNs of the directory objects to which the 
+##### principal object belongs to.
+
+attributetype ( 2.16.840.1.113719.1.301.4.52.1
+                NAME 'krbObjectReferences'
+                EQUALITY distinguishedNameMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+
+
+##### This attribute holds references to a Container object where 
+##### the additional principal objects and stand alone principal 
+##### objects (krbPrincipal) can be created.
+
+attributetype ( 2.16.840.1.113719.1.301.4.53.1
+                NAME 'krbPrincContainerRef'
+                EQUALITY distinguishedNameMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+
+
+##### A list of authentication indicator strings, one of which must be satisfied
+##### to authenticate to the principal as a service.
+##### FreeIPA OID:
+#####  joint-iso-ccitt(3) country(16) us(840) organization(1) netscape(113730)
+#####  ldap(3) freeipa(8) krb5(15) attributes(2)
+attributetype ( 2.16.840.1.113730.3.8.15.2.1
+                NAME 'krbPrincipalAuthInd'
+                EQUALITY caseExactMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.15)
+
+
+##### A list of services to which a service principal can delegate.
+attributetype ( 1.3.6.1.4.1.5322.21.2.4
+                NAME 'krbAllowedToDelegateTo'
+                EQUALITY caseExactIA5Match
+                SUBSTR caseExactSubstringsMatch
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+
+########################################################################
+########################################################################
+#                       Object Class Definitions                       #
+########################################################################
+
+#### This is a kerberos container for all the realms in a tree.
+
+objectclass ( 2.16.840.1.113719.1.301.6.1.1
+                NAME 'krbContainer'
+                SUP top
+                STRUCTURAL
+                MUST ( cn ) )
+
+
+##### The krbRealmContainer is created per realm and holds realm specific data.
+
+objectclass ( 2.16.840.1.113719.1.301.6.2.1
+                NAME 'krbRealmContainer'
+                SUP top
+                STRUCTURAL
+                MUST ( cn )
+                MAY ( krbMKey $ krbUPEnabled $ krbSubTrees $ krbSearchScope $ krbLdapServers $ krbSupportedEncSaltTypes $ krbDefaultEncSaltTypes $ krbTicketPolicyReference $ krbKdcServers $ krbPwdServers $ krbAdmServers $ krbPrincNamingAttr $ krbPwdPolicyReference $ krbPrincContainerRef ) )
+
+
+##### An instance of a class derived from krbService is created per
+##### kerberos authentication or administration server in an realm and holds
+##### references to the realm objects. These references is used to further read
+##### realm specific data to service AS/TGS requests. Additionally this object
+##### contains some server specific data like pathnames and ports that the
+##### server uses. This is the identity the kerberos server logs in with. A key
+##### pair for the same is created and the kerberos server logs in with the same.
+#####
+##### krbKdcService, krbAdmService and krbPwdService derive from this class.
+
+objectclass ( 2.16.840.1.113719.1.301.6.3.1
+                NAME 'krbService'
+                SUP top
+                ABSTRACT
+                MUST ( cn )
+                MAY ( krbHostServer $ krbRealmReferences ) )
+
+
+##### Representative object for the KDC server to bind into a LDAP directory
+##### and have a connection to access Kerberos data with the required 
+##### access rights.
+
+objectclass ( 2.16.840.1.113719.1.301.6.4.1
+                NAME 'krbKdcService'
+                SUP krbService
+                STRUCTURAL )
+
+
+##### Representative object for the Kerberos Password server to bind into a LDAP directory
+##### and have a connection to access Kerberos data with the required
+##### access rights.
+
+objectclass ( 2.16.840.1.113719.1.301.6.5.1
+                NAME 'krbPwdService'
+                SUP krbService
+                STRUCTURAL )
+
+
+###### The principal data auxiliary class. Holds principal information
+###### and is used to store principal information for Person, Service objects.
+
+objectclass ( 2.16.840.1.113719.1.301.6.8.1
+                NAME 'krbPrincipalAux'
+                SUP top
+                AUXILIARY
+                MAY ( krbPrincipalName $ krbCanonicalName $ krbUPEnabled $ krbPrincipalKey $ krbTicketPolicyReference $ krbPrincipalExpiration $ krbPasswordExpiration $ krbPwdPolicyReference $ krbPrincipalType $ krbPwdHistory $ krbLastPwdChange $ krbLastAdminUnlock $ krbPrincipalAliases $ krbLastSuccessfulAuth $ krbLastFailedAuth $ krbLoginFailedCount $ krbExtraData $ krbAllowedToDelegateTo $ krbPrincipalAuthInd ) )
+
+
+###### This class is used to create additional principals and stand alone principals.
+
+objectclass ( 2.16.840.1.113719.1.301.6.9.1
+                NAME 'krbPrincipal'
+                SUP top
+                MUST ( krbPrincipalName )
+                MAY ( krbObjectReferences ) )
+
+
+###### The principal references auxiliary class. Holds all principals referred
+###### from a service
+
+objectclass ( 2.16.840.1.113719.1.301.6.11.1
+                NAME 'krbPrincRefAux'
+                SUP top
+                AUXILIARY
+                MAY krbPrincipalReferences )
+
+
+##### Representative object for the Kerberos Administration server to bind into a LDAP directory
+##### and have a connection Id to access Kerberos data with the required access rights.
+
+objectclass ( 2.16.840.1.113719.1.301.6.13.1
+                NAME 'krbAdmService'
+                SUP krbService 
+                STRUCTURAL )
+
+
+##### The krbPwdPolicy object is a template password policy that 
+##### can be applied to principals when they are created. 
+##### These policy attributes will be in effect, when the Kerberos
+##### passwords are different from users' passwords (UP).
+
+objectclass ( 2.16.840.1.113719.1.301.6.14.1
+                NAME 'krbPwdPolicy' 
+                SUP top
+                MUST ( cn )
+                MAY ( krbMaxPwdLife $ krbMinPwdLife $ krbPwdMinDiffChars $ krbPwdMinLength $ krbPwdHistoryLength $ krbPwdMaxFailure $ krbPwdFailureCountInterval $ krbPwdLockoutDuration $ krbPwdAttributes $ krbPwdMaxLife $ krbPwdMaxRenewableLife $ krbPwdAllowedKeysalts ) )
+
+
+##### The krbTicketPolicyAux holds Kerberos ticket policy attributes.
+##### This class can be attached to a principal object or realm object.
+
+objectclass ( 2.16.840.1.113719.1.301.6.16.1
+                NAME 'krbTicketPolicyAux'
+                SUP top
+                AUXILIARY
+                MAY ( krbTicketFlags $ krbMaxTicketLife $ krbMaxRenewableAge ) )
+
+
+##### The krbTicketPolicy object is an effective ticket policy that is associated with a realm or a principal
+
+objectclass ( 2.16.840.1.113719.1.301.6.17.1
+                NAME 'krbTicketPolicy'
+                SUP top
+                MUST ( cn ) )
+

--- a/image/service/slapd/assets/config/krb5/custom/01-kdc.sh
+++ b/image/service/slapd/assets/config/krb5/custom/01-kdc.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Set default values if they're not overridden by environment variables.
+if [ -z ${LDAP_BASE_DN} ]; then
+  LDAP_BASE_DN="{{ LDAP_BASE_DN }}"
+fi
+if [ -z ${KRB_REALM} ]; then
+  KRB_REALM="{{ KRB_REALM }}"
+fi
+
+#
+# Eeek!
+#
+if [ -z ${LDAP_ADMIN_PASSWORD} ]; then
+  LDAP_ADMIN_PASSWORD="{{ LDAP_ADMIN_PASSWORD }}"
+fi
+if [ -z ${KRB_MASTER_PASSWORD} ]; then
+  KRB_MASTER_PASSWORD="{{ KRB_MASTER_PASSWORD }}"
+fi
+
+#
+# create KDC entries
+#
+coproc kdb5_ldap_util -D cn=admin,${LDAP_BASE_DN} -w ${LDAP_ADMIN_PASSWORD} -H ldapi:// create \
+    -subtrees ou=users,${LDAP_BASE_DN}:ou=services,${LDAP_BASE_DN} -sscope SUB -r ${KRB_REALM}
+echo ${KRB_MASTER_PASSWORD} >&${COPROC[1]}
+echo ${KRB_MASTER_PASSWORD} >&${COPROC[1]}
+wait
+
+# start servers
+service krb5-kdc start
+service krb5-admin-server start

--- a/image/service/slapd/assets/config/krb5/kadm5.acl
+++ b/image/service/slapd/assets/config/krb5/kadm5.acl
@@ -1,0 +1,1 @@
+*/admin@{{ KRB_REALM }} *

--- a/image/service/slapd/assets/config/krb5/kdc.conf
+++ b/image/service/slapd/assets/config/krb5/kdc.conf
@@ -1,0 +1,41 @@
+[kdcdefaults]
+    kdc_ports = 750,88
+
+[realms]
+    SNAPDEVTEAM.COM = {
+        database_module = LDAP
+        admin_keytab = FILE:/etc/krb5kdc/kadm5.keytab
+        acl_file = /etc/krb5kdc/kadm5.acl
+        key_stash_file = /etc/krb5kdc/stash
+        kdc_ports = 750,88
+        max_life = 10h 0m 0s
+        max_renewable_life = 7d 0h 0m 0s
+        master_key_type = des3-hmac-sha1
+        #supported_enctypes = aes256-cts:normal aes128-cts:normal
+        default_principal_flags = +preauth
+    }
+
+#
+# LDAP-backend
+#
+# see https://help.ubuntu.com/lts/serverguide/kerberos-ldap.html.en
+#
+[dbdefaults]
+    ldap_kerberos_container_dn = cn=krbContainer,{{ LDAP_BASE_DN }}
+
+[dbmodules]
+    LDAP = {
+        db_library = kldap
+        ldap_kdc_dn = cn={{ KDC_ADMIN }},{{ LDAP_BASE_DN }}
+
+        # this object needs to have read rights on the
+        # realm container, principal container, and realm sub-trees
+        ldap_kadmind_dn = cn={{ ADM_ADMIN }},{{ LDAP_BASE_DN }}
+
+        # this object needs to have read and write rights on
+        # the realm container, principal container, and realm
+        # sub-trees
+        ldap_service_password_file = /etc/krb5kdc/ldap.stash
+        ldap_servers = ldapi:///
+        ldap_conns_per_server = 5
+    }

--- a/image/service/slapd/assets/config/krb5/krb5.conf
+++ b/image/service/slapd/assets/config/krb5/krb5.conf
@@ -1,0 +1,43 @@
+[logging]
+    default = FILE:/var/log/krb5libs.log
+    kdc = FILE:/var/log/krb5kdc.log
+    admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+    default_realm = {{ KRB_REALM }}
+#   dns_lookup_realm = false
+#   dns_lookup_kdc = false
+
+# The following krb5.conf variables are only for MIT Kerberos.
+    kdc_timesync = 1
+    ccache_type = 4
+    forwardable = true
+    proxiable = true
+
+# The following encryption type specification will be used by MIT Kerberos
+# if uncommented.  In general, the defaults in the MIT Kerberos code are
+# correct and overriding these specifications only serves to disable new
+# encryption types as they are added, creating interoperability problems.
+#
+# The only time when you might need to uncomment these lines and change
+# the enctypes is if you have local software that will break on ticket
+# caches containing ticket encryption types it doesn't know about (such as
+# old versions of Sun Java).
+
+#   default_tgs_enctypes = des3-hmac-sha1
+#   default_tkt_enctypes = des3-hmac-sha1
+#   permitted_enctypes = des3-hmac-sha1
+
+# The following libdefaults parameters are only for Heimdal Kerberos.
+    fcc-mit-ticketflags = true
+
+[realms]
+    {{ KRB_REALM }} = {
+        kdc = {{ KDC_SERVER }}
+        admin_server = {{ ADM_SERVER }}
+        default_domain = {{ LDAP_DOMAIN }}
+    }
+
+[domain_realm]
+    .{{ LDAP_DOMAIN }} = {{ KRB_REALM }}
+    {{ LDAP_DOMAIN }} = {{ KRB_REALM }}


### PR DESCRIPTION
This patch adds the configuration and initialization of a MIT(Kerberos) KDC. It is 90% complete but the final bit requires thought by the upstream maintainer.

The changes fall into three broad categories.

**The items with a modest impact that can easily be integrated into stable.**

1. Creation of the /etc/krb5.conf, /etc/krb5kdc/kdc.conf, and /etc/krb5kdc/kadm5.conf files configured to refer to the OpenLDAP server.

2. Addition of kerberos.schema to the list of default schemas, plus modest changes to the bootstrap ldif files for tasks like adding an index on krbPrincipalName.

3. Addition of krb5-admin-server as a Debian dependency.

**The items that should only be performed conditionally.**

1. Creation of three bootstrap/ldif/custom files that create a few entries, modify the ACLs, then delete the entries so kdb5-ldap-util can run as usual later. I put them in ldif/custom since they also define two ou but it maybe better to put them into a new directory (ldif/krb5) and delete the ou as well. Creation of the ou can be deferred until the script mentioned below. This is required since we want the ACLs to limit access to the KDC information since it contains sensitive information but we can't change the ACLs on a running server.

2. Stashing the ldap admin password for use by the kdc and kadmin servers. This is really iffy since the password is unencrypted.

**The items that can only be performed once the LDAP server is running**

I don't know if there's an easy way to run scripts once the LDAP server is running - for now I'm just creating a script in /usr/local/bin/01-kdc.sh that does the following tasks:

1. (create the ou currently created in ldif/custom/01-groups.ldif?)

2. Run kdb5-ldap-util to populate the LDAP database with the required KDC entries.

3. Start the krb5-kdc and krb5-admin-server servers.
