### PR TITLE
Support for docker secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Latest release: 1.2.4 - OpenLDAP 2.4.47 -  [Changelog](CHANGELOG.md) | [Docker H
 		- [Set your own environment variables](#set-your-own-environment-variables)
 			- [Use command line argument](#use-command-line-argument)
 			- [Link environment file](#link-environment-file)
+			- [Docker Secrets](#docker-secrets)
 			- [Make your own image or extend this image](#make-your-own-image-or-extend-this-image)
 	- [Advanced User Guide](#advanced-user-guide)
 		- [Extend osixia/openldap:1.2.4 image](#extend-osixiaopenldap124-image)
@@ -365,6 +366,17 @@ Note: the container will try to delete the **\*.startup.yaml** file after the en
 
 	docker run --volume /data/ldap/environment/my-env.yaml:/container/environment/01-custom/env.yaml \
 	--detach osixia/openldap:1.2.4
+
+#### Docker Secrets
+
+As an alternative to passing sensitive information via environmental variables, _FILE may be appended to the listed variables, causing 
+the startup.sh script to load the values for those values from files presented in the container. This is particular usefull for loading
+passwords using the [Docker secrets](https://docs.docker.com/engine/swarm/secrets/) mechanism. For example:
+
+	docker run --env LDAP_ORGANISATION="My company" --env LDAP_DOMAIN="my-company.com" \
+	--env LDAP_ADMIN_PASSWORD_FILE=/run/secrets/authentication_admin_pw --detach osixia/openldap:1.2.4
+
+Currently this is only supported for LDAP_ADMIN_PASSWORD, LDAP_CONFIG_PASSWORD, LDAP_READONLY_USER_PASSWORD
 
 #### Make your own image or extend this image
 

--- a/test/test.bats
+++ b/test/test.bats
@@ -38,6 +38,21 @@ load test_helper
 
 }
 
+@test "ldapsearch database with password provided from file" {
+
+  rm $PWD/password.txt && touch $PWD/password.txt 
+  echo "strongPassword" >> $PWD/password.txt
+
+  run_image -h ldap.osixia.net -e LDAP_ADMIN_PASSWORD_FILE=/run/secrets/admin_pw.txt --volume $PWD/password.txt:/run/secrets/admin_pw.txt
+  wait_process slapd
+  run docker exec $CONTAINER_ID ldapsearch -x -h ldap.osixia.net -b dc=example,dc=org -ZZ -D "cn=admin,dc=example,dc=org" -w strongPassword
+  clear_container
+  rm $PWD/password.txt
+
+  [ "$status" -eq 0 ]
+}
+
+
 @test "ldapsearch new database with strict TLS" {
 
   run_image -h ldap.example.org


### PR DESCRIPTION
The merge request implements support for docker secrets. 
More or less it allows you to do:

```
version: '3.3'

services:
  openldap:
    image: anagno/openldap:latest
    environment:
      LDAP_DOMAIN: "anagno.me"
      LDAP_ORGANISATION: "anagno"
      LDAP_ADMIN_PASSWORD_FILE: /run/secrets/authentication_admin_pw
      LDAP_CONFIG_PASSWORD_FILE: /run/secrets/authentication_config_pw
      LDAP_READONLY_USER: "true"
      LDAP_READONLY_USER_USERNAME: "readonly"
      LDAP_READONLY_USER_PASSWORD_FILE: /run/secrets/authentication_readonly_pw
    secrets:
      - authentication_admin_pw
      - authentication_config_pw
      - authentication_readonly_pw

secrets:
  authentication_admin_pw:
    external: true
  authentication_config_pw:
    external: true
  authentication_readonly_pw:
    external: true
```

It follows the same pattern that the postgesql (https://hub.docker.com/_/postgres) and mariadb dockerfile follows (i.e. appending _FILE in the end of the variables). 
The only difference from their approach is that I do not check if the variable already exists. Mainly, because all the variables are declared from the docker-light-baseimage. So when _FILE variable is declared, it will overwrite the values. 

I hope it is useful.
If something is not clear (or wrong), please let me know and I will try to explain it (fix it)  :)

