### PR TITLE
Updating the reference to bats and fixing the UT

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Run your image:
 
 We use **Bats** (Bash Automated Testing System) to test this image:
 
-> [https://github.com/sstephenson/bats](https://github.com/sstephenson/bats)
+> [https://github.com/bats-core/bats-core](https://github.com/bats-core/bats-core)
 
 Install Bats, and in this project directory run:
 

--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -43,7 +43,7 @@ file_env 'LDAP_READONLY_USER_PASSWORD'
 [ -d /etc/ldap/slapd.d ] || mkdir -p /etc/ldap/slapd.d
 
 # fix file permissions
-if [ "${DISABLE_CHOWN,,}" == "true" ]; then
+if [ "${DISABLE_CHOWN,,}" == "false" ]; then
   chown -R openldap:openldap /var/lib/ldap
   chown -R openldap:openldap /etc/ldap
   chown -R openldap:openldap ${CONTAINER_SERVICE_DIR}/slapd
@@ -158,7 +158,7 @@ EOF
       mv /tmp/schema/cn=config/cn=schema/* /etc/ldap/slapd.d/cn=config/cn=schema
       rm -r /tmp/schema
 
-      if [ "${DISABLE_CHOWN,,}" == "true" ]; then
+      if [ "${DISABLE_CHOWN,,}" == "false" ]; then
         chown -R openldap:openldap /etc/ldap/slapd.d/cn=config/cn=schema
       fi
     fi
@@ -237,7 +237,7 @@ EOF
       ssl-helper $LDAP_SSL_HELPER_PREFIX $PREVIOUS_LDAP_TLS_CRT_PATH $PREVIOUS_LDAP_TLS_KEY_PATH $PREVIOUS_LDAP_TLS_CA_CRT_PATH
       [ -f ${PREVIOUS_LDAP_TLS_DH_PARAM_PATH} ] || openssl dhparam -out ${LDAP_TLS_DH_PARAM_PATH} 2048
 
-      if [ "${DISABLE_CHOWN,,}" == "true" ]; then
+      if [ "${DISABLE_CHOWN,,}" == "false" ]; then
         chmod 600 ${PREVIOUS_LDAP_TLS_DH_PARAM_PATH}
         chown openldap:openldap $PREVIOUS_LDAP_TLS_CRT_PATH $PREVIOUS_LDAP_TLS_KEY_PATH $PREVIOUS_LDAP_TLS_CA_CRT_PATH $PREVIOUS_LDAP_TLS_DH_PARAM_PATH
       fi
@@ -345,7 +345,7 @@ EOF
       [ -f ${LDAP_TLS_DH_PARAM_PATH} ] || openssl dhparam -out ${LDAP_TLS_DH_PARAM_PATH} 2048
       
       # fix file permissions
-      if [ "${DISABLE_CHOWN,,}" == "true" ]; then
+      if [ "${DISABLE_CHOWN,,}" == "false" ]; then
         chmod 600 ${LDAP_TLS_DH_PARAM_PATH}
         chown -R openldap:openldap ${CONTAINER_SERVICE_DIR}/slapd
       fi


### PR DESCRIPTION
This pull request:
* Updates the reference to the official site of bats
* Fixes a small mistake in the implementation of DISABLE_CHOWN. The current implementation makes some of the UT to fail. I am guessing that we should have compared the variable to false, instead of true. 

I hope it is useful.
If something is not clear (or wrong), please let me know and I will try to explain it (fix it) :)