### PR TITLE
Adding multiarch support and continues integration support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,134 @@
+language: bash
+
+services:
+  - docker
+env:
+  global:
+    - NAME="anagno/openldap"
+    - VERSION="${TRAVIS_BRANCH}-dev"
+  matrix:
+    - TARGET_ARCH=amd64 QEMU_ARCH=x86_64
+    - TARGET_ARCH=i386 QEMU_ARCH=i386
+    - TARGET_ARCH=arm32v7 QEMU_ARCH=arm
+    - TARGET_ARCH=arm64v8 QEMU_ARCH=aarch64
+
+addons:
+  apt:
+    # The docker manifest command was added in docker-ee version 18.x
+    # So update our current installation and we also have to enable the experimental features.
+    sources:
+    - sourceline: 'deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable'
+      key_url: 'https://download.docker.com/linux/ubuntu/gpg'
+    packages:
+      - docker-ce
+
+before_install:
+  - docker --version
+  - mkdir $HOME/.docker
+  - 'echo "{" > $HOME/.docker/config.json'
+  - 'echo "  \"experimental\": \"enabled\"" >> $HOME/.docker/config.json'
+  - 'echo "}" >> $HOME/.docker/config.json'
+  - sudo service docker restart
+
+install:
+    # For cross buidling our images
+    # This is necessary because travis-ci.org has only x86_64 machines.
+    # If travis-ci.org gets native arm builds, probably this step is not
+    # necessary any more.
+  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+    # Bats is necessary for the UT
+  - curl -o bats.tar.gz -SL https://github.com/bats-core/bats-core/archive/v1.1.0.tar.gz
+  - mkdir bats-core && tar -xf bats.tar.gz -C bats-core --strip-components=1
+  - cd bats-core/
+  - sudo ./install.sh /usr/local
+  - cd ..
+
+before_script:
+  # Injecting the necessary information and binaries for cross-compiling the images.
+  # In native builds this information and binaries are not necessary and that is why
+  # we are injecting them in the build scripts and we do not include them in the Dockerfiles 
+  - if [[ "${TARGET_ARCH}" != 'amd64' ]]; then
+      sed -i "/FROM .*\/light-baseimage:/ s/[[:blank:]]*$/-${TARGET_ARCH}/" image/Dockerfile;
+    fi
+  - if [[ "${TARGET_ARCH}" != 'amd64' ]]; then
+        sed -i "/FROM .*\/light-baseimage/a COPY \
+        --from=multiarch/qemu-user-static:x86_64-${QEMU_ARCH} \
+        /usr/bin/qemu-${QEMU_ARCH}-static /usr/bin/" image/Dockerfile;
+    fi
+  - cat image/Dockerfile;
+  # If this is a tag then change the VERSION variable to only have the
+  # tag name and not also the commit hash.
+  - if [ -n "$TRAVIS_TAG" ]; then
+      VERSION=$(echo "${TRAVIS_TAG}" | sed -e 's/\(.*\)[-v]\(.*\)/\1\2/g');
+    fi
+
+script:
+  - make build-nocache NAME=${NAME} VERSION=${VERSION}-${TARGET_ARCH}
+  - if [[ "${TARGET_ARCH}" == 'amd64' ]]; then
+      make test NAME=${NAME} VERSION=${VERSION}-${TARGET_ARCH};
+    fi
+
+after_success:
+  - if [[ "${TARGET_ARCH}" != 'amd64' ]]; then
+      make test NAME=${NAME} VERSION=${VERSION}-${TARGET_ARCH};
+    fi
+
+before_deploy:
+  - docker run -d --name test_image ${NAME}:${VERSION}-${TARGET_ARCH} sleep 10
+  - sleep 5
+  - sudo docker ps | grep -q test_image
+  # To have `DOCKER_USER` and `DOCKER_PASS`
+  # use `travis env set`.
+  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASS";
+  - make tag NAME=${NAME} VERSION=${VERSION}-${TARGET_ARCH}
+
+deploy:
+  provider: script
+  on:
+    repo: anagno/docker-openldap
+    all_branches: true
+  script: make push NAME=${NAME} VERSION=${VERSION}-${TARGET_ARCH}
+
+jobs:
+  include:
+    - stage: Manifest creation
+      install: skip
+      script: skip
+      after_success:
+        - docker login -u "$DOCKER_USER" -p "$DOCKER_PASS";
+        - docker manifest create ${NAME}:${VERSION} 
+            ${NAME}:${VERSION}-amd64 
+            ${NAME}:${VERSION}-i386 
+            ${NAME}:${VERSION}-arm32v7 
+            ${NAME}:${VERSION}-arm64v8;
+          docker manifest annotate ${NAME}:${VERSION} 
+            ${NAME}:${VERSION}-amd64 --os linux --arch amd64;
+          docker manifest annotate ${NAME}:${VERSION} 
+            ${NAME}:${VERSION}-i386 --os linux --arch 386;
+          docker manifest annotate ${NAME}:${VERSION} 
+            ${NAME}:${VERSION}-arm32v7 --os linux --arch arm --variant v7;
+          docker manifest annotate ${NAME}:${VERSION} 
+            ${NAME}:${VERSION}-arm64v8 --os linux --arch arm64 --variant v8;
+
+        # The latest tag is coming from the stable branch of the repo
+        - if [ "${TRAVIS_BRANCH}" == 'stable' ]; then
+            docker manifest create ${NAME}:latest 
+              ${NAME}:${VERSION}-amd64 
+              ${NAME}:${VERSION}-i386 
+              ${NAME}:${VERSION}-arm32v7 
+              ${NAME}:${VERSION}-arm64v8;
+            docker manifest annotate ${NAME}:latest 
+              ${NAME}:${VERSION}-amd64 --os linux --arch amd64;
+            docker manifest annotate ${NAME}:latest 
+              ${NAME}:${VERSION}-i386 --os linux --arch 386;
+            docker manifest annotate ${NAME}:latest 
+              ${NAME}:${VERSION}-arm32v7 --os linux --arch arm --variant v7;
+            docker manifest annotate ${NAME}:latest 
+              ${NAME}:${VERSION}-arm64v8 --os linux --arch arm64 --variant v8;
+          fi
+
+        - docker manifest push ${NAME}:${VERSION};
+          if [ "${TRAVIS_BRANCH}" == 'stable' ]; then
+            docker manifest push ${NAME}:latest;
+          fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
     - stage: Manifest creation
       install: skip
       script: skip
-      after_success:
+      after_deploy:
         - docker login -u "$DOCKER_USER" -p "$DOCKER_PASS";
         - docker manifest create ${NAME}:${VERSION} 
             ${NAME}:${VERSION}-amd64 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ test:
 tag-latest:
 	docker tag $(NAME):$(VERSION) $(NAME):latest
 
+tag:
+	docker tag $(NAME):$(VERSION) $(NAME):$(VERSION)
+
 push:
 	docker push $(NAME):$(VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-NAME = osixia/openldap
-VERSION = 1.2.4
+NAME = anagno/openldap
+VERSION = 1.2.5-dev
+
 
 .PHONY: build build-nocache test tag-latest push push-latest release git-tag-version
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,6 +1,6 @@
 # Use osixia/light-baseimage
 # sources: https://github.com/osixia/docker-light-baseimage
-FROM osixia/light-baseimage:1.1.2
+FROM anagno/light-baseimage:travis-dev
 
 ARG LDAP_OPENLDAP_GID
 ARG LDAP_OPENLDAP_UID
@@ -10,15 +10,13 @@ ARG LDAP_OPENLDAP_UID
 RUN if [ -z "${LDAP_OPENLDAP_GID}" ]; then groupadd -r openldap; else groupadd -r -g ${LDAP_OPENLDAP_GID} openldap; fi \
     && if [ -z "${LDAP_OPENLDAP_UID}" ]; then useradd -r -g openldap openldap; else useradd -r -g openldap -u ${LDAP_OPENLDAP_UID} openldap; fi
 
-# Add stretch-backports in preparation for downloading newer openldap components, especially sladp
-RUN echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list
 
 # Install OpenLDAP, ldap-utils and ssl-tools from the (backported) baseimage and clean apt-get files
 # sources: https://github.com/osixia/docker-light-baseimage/blob/stable/image/tool/add-service-available
 #          https://github.com/osixia/docker-light-baseimage/blob/stable/image/service-available/:ssl-tools/download.sh
 RUN echo "path-include /usr/share/doc/krb5*" >> /etc/dpkg/dpkg.cfg.d/docker && apt-get -y update \
     && /container/tool/add-service-available :ssl-tools \
-	  && LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get -t stretch-backports install -y --no-install-recommends \
+	  && LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        ldap-utils \
        libsasl2-modules \
        libsasl2-modules-db \


### PR DESCRIPTION
!!!! IMPORTANT!!!!
This merge request needs the https://github.com/osixia/docker-light-baseimage/pull/16 to be merge first in the base image. For the moment I am using my own image (which has integrated the changes from PR-16). So before merging (if this gets accepted of course :) ) we will have to change the references to the official images. 
!!!! ---- !!!!

This merge request implements multi arch support for the docker-openldap image and this is achieved by the travis.yml (I follow the same logic from the base-image and PR-16 in the base image).

Caveats:
I do not why, but some of the UT in the non x86_64 architectures, when executed by travis.org were failing (https://travis-ci.org/anagno/docker-openldap/builds/558298708). An example can be found [here](https://travis-ci.org/anagno/docker-openldap/jobs/558298711#L902). 

I am not sure if it indicates a problem with the base image or with travis itself, but when I compiled the image in my raspberry pi, all UT were passing. When I deployed the experimental image in the raspberry pi from docker hub, it seems to be working correct.  

For the moment, I made in travis.yml the UT for the other architectures optional (i.e. if the UT in amd64 fails, then the build will fail. But if the UT in all other platforms fail, the build will not fail and it will be deployed). This is not the best solution, but I could not find the reason for this failure. Is there a way that I can execute the UT in a image from the docker hub?

I hope it is useful. Any feedback will be greatly appreciated !
If something is not clear (or wrong), please let me know and I will try to explain it (fix it) :)
