### PR TITLE
Address firewall issues on RHEL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Docker Engine doesn't work well with firewall-cmd and can cause issues if you're
 ```
 $ firewall-cmd --add-port=389/tcp --permanent
 $ firewall-cmd --add-port=636/tcp --permanent
+$ firewall-cmd --reload
 ```
 Learn more about this issue at https://github.com/moby/moby/issues/32138
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ For more information about docker data volume, please refer to:
 
 > [https://docs.docker.com/engine/tutorials/dockervolumes/](https://docs.docker.com/engine/tutorials/dockervolumes/)
 
+#### Firewall issues on RHEL/CentOS
+Docker Engine doesn't work well with firewall-cmd and can cause issues if you're connecting to the LDAP server from another container on the same machine. You can fix this by running:
+```
+$ firewall-cmd --add-port=389/tcp --permanent
+$ firewall-cmd --add-port=636/tcp --permanent
+```
+Learn more about this issue at https://github.com/moby/moby/issues/32138
 
 #### Edit your server configuration
 


### PR DESCRIPTION
Docker Engine doesn't work well with firewall-cmd and can cause issues if you're connecting to the LDAP server from another container on the same machine. 

https://github.com/moby/moby/issues/32138