### PR TITLE
Allow setting ports on ldap and ldaps

### DIFF
--- a/image/environment/default.yaml
+++ b/image/environment/default.yaml
@@ -14,3 +14,7 @@ LDAP_NOFILE: 1024
 
 # Do not perform any chown to fix file ownership
 DISABLE_CHOWN: false
+
+# Default port to bind slapd
+LDAP_PORT: 389
+LDAPS_PORT: 636

--- a/image/service/slapd/process.sh
+++ b/image/service/slapd/process.sh
@@ -9,4 +9,4 @@ log-helper level eq trace && set -x
 # see https://github.com/docker/docker/issues/8231
 ulimit -n $LDAP_NOFILE
 
-exec /usr/sbin/slapd -h "ldap://$HOSTNAME ldaps://$HOSTNAME ldapi:///" -u openldap -g openldap -d $LDAP_LOG_LEVEL
+exec /usr/sbin/slapd -h "ldap://$HOSTNAME:$LDAP_PORT ldaps://$HOSTNAME:$LDAPS_PORT ldapi:///" -u openldap -g openldap -d $LDAP_LOG_LEVEL


### PR DESCRIPTION
This PR adds the ability to specify the ports where OpenLDAP will listen for LDAP and LDAPS protocols. By default they are set to the standard 389 and 636 respectively and they can be overriden by setting the `LDAP_PORT` and/or `LDAPS_PORT` at runtime.

I think this fixes https://github.com/osixia/docker-openldap/issues/165