### PR TITLE
[FIX] #402: grant root manage access to database

### DIFF
--- a/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/02-security.ldif
@@ -3,5 +3,6 @@ changetype: modify
 delete: olcAccess
 -
 add: olcAccess
+olcAccess: to * by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage by * break
 olcAccess: to attrs=userPassword,shadowLastChange by self write by dn="cn=admin,{{ LDAP_BASE_DN }}" write by anonymous auth by * none
 olcAccess: to * by self read by dn="cn=admin,{{ LDAP_BASE_DN }}" write by * none

--- a/image/service/slapd/assets/config/bootstrap/ldif/readonly-user/readonly-user-acl.ldif
+++ b/image/service/slapd/assets/config/bootstrap/ldif/readonly-user/readonly-user-acl.ldif
@@ -3,5 +3,6 @@ changetype: modify
 delete: olcAccess
 -
 add: olcAccess
+olcAccess: to * by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage by * break
 olcAccess: to attrs=userPassword,shadowLastChange by self write by dn="cn=admin,{{ LDAP_BASE_DN }}" write by anonymous auth by * none
 olcAccess: to * by self read by dn="cn=admin,{{ LDAP_BASE_DN }}" write by dn="cn={{ LDAP_READONLY_USER_USERNAME }},{{ LDAP_BASE_DN }}" read by * none


### PR DESCRIPTION
Fixes the Issues:

- #402 
- #413 

Adds an acl to explicitly grant 'root' rights to modify the ldap database, otherwise 
```
ldapmodify -Y EXTERNAL -H ldapi:/// -f <FILE>
```
fails.

I've built and uploaded the image to dockerhub: [oliadev/openldap:1.3.0](https://hub.docker.com/r/oliadev/openldap)