### PR TITLE
Changing tag for baseimage

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,6 +1,6 @@
 # Use osixia/light-baseimage
 # sources: https://github.com/osixia/docker-light-baseimage
-FROM osixia/light-baseimage:release-1.2.0-dev
+FROM osixia/light-baseimage:latest
 
 ARG LDAP_OPENLDAP_GID
 ARG LDAP_OPENLDAP_UID


### PR DESCRIPTION
As the Dockerfile hasn't been updated in while, changing the tag to "latest" ensure no one doubts it is up to date, sort of.