### PR TITLE
Add Note About Read-only User Password

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Required and used for new ldap server only:
 - **LDAP_CONFIG_PASSWORD** Ldap Config password. Defaults to `config`
 
 - **LDAP_READONLY_USER** Add a read only user. Defaults to `false`
+  > **Note:** The read only user **does** have write access to its own password.
 - **LDAP_READONLY_USER_USERNAME** Read only user username. Defaults to `readonly`
 - **LDAP_READONLY_USER_PASSWORD** Read only user password. Defaults to `readonly`
 


### PR DESCRIPTION
Add note indicating that the read-only user account can write its own password.

This was a little confusing to me, but I guess it makes sense. I think a note would still help, though.