### PR TITLE
Add missing LDAP_DOMAIN substitution to custom LDIF README

### DIFF
--- a/image/service/slapd/assets/config/bootstrap/ldif/custom/README.md
+++ b/image/service/slapd/assets/config/bootstrap/ldif/custom/README.md
@@ -5,6 +5,7 @@ The startup script provides some substitutions in bootstrap ldif files. Followin
 
 - `{{ LDAP_BASE_DN }}`
 - `{{ LDAP_BACKEND }}`
+- `{{ LDAP_DOMAIN }}`
 - `{{ LDAP_READONLY_USER_USERNAME }}`
 - `{{ LDAP_READONLY_USER_PASSWORD_ENCRYPTED }}`
 


### PR DESCRIPTION
This is already documented in the main README file but is missing from this one.