### PR TITLE
fix custom ldap file and schema

### DIFF
--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -41,15 +41,15 @@ file_env 'LDAP_READONLY_USER_PASSWORD'
 # Seed ldif from internal path if specified
 file_env 'LDAP_SEED_INTERNAL_LDIF_PATH'
 if [ ! -z "${LDAP_SEED_INTERNAL_LDIF_PATH}" ]; then
-  mkdir -p /container/service/slapd/assets/config/bootstrap/ldif/custom/
-  cp -R ${LDAP_SEED_INTERNAL_LDIF_PATH}/*.ldif /container/service/slapd/assets/config/bootstrap/ldif/custom/
+  mkdir -p ${CONTAINER_SERVICE_DIR}/slapd/assets/config/bootstrap/ldif/custom/
+  cp -R ${LDAP_SEED_INTERNAL_LDIF_PATH}/*.ldif ${CONTAINER_SERVICE_DIR}/slapd/assets/config/bootstrap/ldif/custom/
 fi
 
 # Seed schema from internal path if specified
 file_env 'LDAP_SEED_INTERNAL_SCHEMA_PATH'
 if [ ! -z "${LDAP_SEED_INTERNAL_SCHEMA_PATH}" ]; then
-  mkdir -p /container/service/slapd/assets/config/bootstrap/schema/custom/
-  cp -R ${LDAP_SEED_INTERNAL_SCHEMA_PATH}/*.schema /container/service/slapd/assets/config/bootstrap/schema/custom/
+  mkdir -p ${CONTAINER_SERVICE_DIR}/slapd/assets/config/bootstrap/schema/custom/
+  cp -R ${LDAP_SEED_INTERNAL_SCHEMA_PATH}/*.schema ${CONTAINER_SERVICE_DIR}/slapd/assets/config/bootstrap/schema/custom/
 fi
 
 # create dir if they not already exists


### PR DESCRIPTION
Hi I'm using this image and trying to use customize ldfi file when initial, but this feature seem doesn't work
After I check startup.sh I find this issue

in line 44 should use ${CONTAINER_SERVICE_DIR}, 
because when using `--copy-service` the ${CONTAINER_SERVICE_DIR} will be /container/run/service
and the custom boostrap ldif execution in line 366 is using `${CONTAINER_SERVICE_DIR}/slapd/assets/config/bootstrap/ldif/custom`