### PR TITLE
Multimaster replication k8s compatibility: Introduce LDAP_TLS_CERTS_COPY_FROM, fix host param and FIRST_START_DONE

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,8 @@ TLS options:
 - **LDAP_TLS_CRT_FILENAME**: Ldap ssl certificate filename. Defaults to `ldap.crt`
 - **LDAP_TLS_KEY_FILENAME**: Ldap ssl certificate private key filename. Defaults to `ldap.key`
 - **LDAP_TLS_DH_PARAM_FILENAME**: Ldap ssl certificate dh param file. Defaults to `dhparam.pem`
-- **LDAP_TLS_CA_CRT_FILENAME**: Ldap ssl CA certificate  filename. Defaults to `ca.crt`
+- **LDAP_TLS_CA_CRT_FILENAME**: Ldap ssl CA certificate filename. Defaults to `ca.crt`
+- **LDAP_TLS_CERTS_COPY_FROM**: The path to copy certificates from. Defaults to empty.
 - **LDAP_TLS_ENFORCE**: Enforce TLS but except ldapi connections. Can't be disabled once set to true. Defaults to `false`.
 - **LDAP_TLS_CIPHER_SUITE**: TLS cipher suite. Defaults to `SECURE256:+SECURE128:-VERS-TLS-ALL:+VERS-TLS1.2:-RSA:-DHE-DSS:-CAMELLIA-128-CBC:-CAMELLIA-256-CBC`, based on Red Hat's [TLS hardening guide](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Hardening_TLS_Configuration.html)
 - **LDAP_TLS_VERIFY_CLIENT**: TLS verify client. Defaults to `demand`

--- a/image/environment/default.startup.yaml
+++ b/image/environment/default.startup.yaml
@@ -30,6 +30,9 @@ LDAP_TLS_KEY_FILENAME: ldap.key
 LDAP_TLS_DH_PARAM_FILENAME: dhparam.pem
 LDAP_TLS_CA_CRT_FILENAME: ca.crt
 
+# copy certs from this directory to the default certs directory, to workaround that the mounted filesystem is read-only
+LDAP_TLS_CERTS_COPY_FROM:
+
 LDAP_TLS_ENFORCE: false
 LDAP_TLS_CIPHER_SUITE: SECURE256:+SECURE128:-VERS-TLS-ALL:+VERS-TLS1.2:-RSA:-DHE-DSS:-CAMELLIA-128-CBC:-CAMELLIA-256-CBC
 LDAP_TLS_VERIFY_CLIENT: demand

--- a/image/service/slapd/process.sh
+++ b/image/service/slapd/process.sh
@@ -9,11 +9,13 @@ log-helper level eq trace && set -x
 # see https://github.com/docker/docker/issues/8231
 ulimit -n $LDAP_NOFILE
 
-# FIXME: why use FQDN??
 # Call hostname to determine the fully qualified domain name. We want OpenLDAP to listen
 # to the named host for the ldap:// and ldaps:// protocols.
 # FQDN="$(/bin/hostname --fqdn)"
 # HOST_PARAM="ldap://$FQDN:$LDAP_PORT ldaps://$FQDN:$LDAPS_PORT"
 # HOST_PARAM="ldap://$HOSTNAME:$LDAP_PORT ldaps://$HOSTNAME:$LDAPS_PORT"
+
+# NOTE: $HOST_PARAM must be consistent with olcServerID, so we should only use $HOSTNAME here, no $FQDN, no port. This
+# is more friendly with the setup in k8s, as in k8s the FQDN will be the cluster domain which normally you don't want.
 HOST_PARAM="ldap://$HOSTNAME ldaps://$HOSTNAME"
 exec /usr/sbin/slapd -h "$HOST_PARAM ldapi:///" -u openldap -g openldap -d "$LDAP_LOG_LEVEL"

--- a/image/service/slapd/process.sh
+++ b/image/service/slapd/process.sh
@@ -14,5 +14,6 @@ ulimit -n $LDAP_NOFILE
 # to the named host for the ldap:// and ldaps:// protocols.
 # FQDN="$(/bin/hostname --fqdn)"
 # HOST_PARAM="ldap://$FQDN:$LDAP_PORT ldaps://$FQDN:$LDAPS_PORT"
-HOST_PARAM="ldap://$HOSTNAME:$LDAP_PORT ldaps://$HOSTNAME:$LDAPS_PORT"
+# HOST_PARAM="ldap://$HOSTNAME:$LDAP_PORT ldaps://$HOSTNAME:$LDAPS_PORT"
+HOST_PARAM="ldap://$HOSTNAME ldaps://$HOSTNAME"
 exec /usr/sbin/slapd -h "$HOST_PARAM ldapi:///" -u openldap -g openldap -d "$LDAP_LOG_LEVEL"

--- a/image/service/slapd/process.sh
+++ b/image/service/slapd/process.sh
@@ -9,8 +9,10 @@ log-helper level eq trace && set -x
 # see https://github.com/docker/docker/issues/8231
 ulimit -n $LDAP_NOFILE
 
+# FIXME: why use FQDN??
 # Call hostname to determine the fully qualified domain name. We want OpenLDAP to listen
 # to the named host for the ldap:// and ldaps:// protocols.
-FQDN="$(/bin/hostname --fqdn)"
-HOST_PARAM="ldap://$FQDN:$LDAP_PORT ldaps://$FQDN:$LDAPS_PORT"
+# FQDN="$(/bin/hostname --fqdn)"
+# HOST_PARAM="ldap://$FQDN:$LDAP_PORT ldaps://$FQDN:$LDAPS_PORT"
+HOST_PARAM="ldap://$HOSTNAME:$LDAP_PORT ldaps://$HOSTNAME:$LDAPS_PORT"
 exec /usr/sbin/slapd -h "$HOST_PARAM ldapi:///" -u openldap -g openldap -d "$LDAP_LOG_LEVEL"

--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -506,10 +506,7 @@ EOF
       sed -i "s|{{ LDAP_BASE_DN }}|${LDAP_BASE_DN}|g" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/admin-pw/ldif/07-admin-pw-change.ldif
 
       for f in $(find ${CONTAINER_SERVICE_DIR}/slapd/assets/config/admin-pw/ldif -type f -name \*.ldif  | sort); do
-        # FIXME: why no admin DN?
-        set +e
         ldap_add_or_modify "$f"
-        set -e
       done
     else
        touch "$WAS_ADMIN_PASSWORD_SET"

--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -506,7 +506,10 @@ EOF
       sed -i "s|{{ LDAP_BASE_DN }}|${LDAP_BASE_DN}|g" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/admin-pw/ldif/07-admin-pw-change.ldif
 
       for f in $(find ${CONTAINER_SERVICE_DIR}/slapd/assets/config/admin-pw/ldif -type f -name \*.ldif  | sort); do
+        # FIXME: there's no admin user, admin is the rootDN of mdb, 07-admin-pw-change.ldif will fail
+        set +x
         ldap_add_or_modify "$f"
+        set -x
       done
     else
        touch "$WAS_ADMIN_PASSWORD_SET"


### PR DESCRIPTION
*This PR is not very clean but just put here for reference. In case someone want to setup multimaster replication in k8s.*

- Introduce LDAP_TLS_CERTS_COPY_FROM
- fix host param
- fix FIRST_START_DONE
- fix 07-admin-pw-change.ldif failing

Example statefulset yaml:

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ldap
  namespace: infrastructure
  labels:
    app: ldap
spec:
  podManagementPolicy: Parallel
  replicas: 2
  selector:
    matchLabels:
      app: ldap
  serviceName: ldap
  template:
    metadata:
      labels:
        app: ldap
    spec:
      containers:
      - args:
        - -l
        - trace
        image: tclh123/openldap:certs-5
        imagePullPolicy: Always
        name: ldap
        ports:
        - containerPort: 389
          name: ldap
          protocol: TCP
        - containerPort: 636
          name: ldaps
          protocol: TCP
        resources:
          limits:
            cpu: "1"
            memory: 1Gi
          requests:
            cpu: "1"
            memory: 1Gi
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /container/environment/01-custom
          name: ldap-cm
          readOnly: true
        - mountPath: /certs
          name: ldap-secrets-cm
          readOnly: true
        - mountPath: /var/lib/ldap
          name: ldap-data
          subPath: data
        - mountPath: /etc/ldap/slapd.d
          name: ldap-data
          subPath: config-data
        - mountPath: /container/service/slapd/assets/certs
          name: ldap-data
          subPath: certs
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      terminationGracePeriodSeconds: 30
      volumes:
      - configMap:
          defaultMode: 420
          name: ldap-cm
        name: ldap-cm
      - configMap:
          defaultMode: 420
          name: ldap-secrets-cm
        name: ldap-secrets-cm
  updateStrategy:
    type: RollingUpdate
  volumeClaimTemplates:
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      name: ldap-data
      labels:
        app: ldap
    spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 20Gi
      storageClassName: ondemand
      volumeMode: Filesystem
```