### PR TITLE
Update to baseimage v1.3.1 to fix expired default-ca

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,6 +1,6 @@
 # Use osixia/light-baseimage
 # sources: https://github.com/osixia/docker-light-baseimage
-FROM osixia/light-baseimage:1.2.0
+FROM osixia/light-baseimage:1.3.1
 
 ARG LDAP_OPENLDAP_GID
 ARG LDAP_OPENLDAP_UID


### PR DESCRIPTION
Fixes https://github.com/osixia/docker-openldap/issues/506
Fixes #504 (together with other PR #525)

Follup-up from https://github.com/osixia/docker-light-baseimage/pull/30