### PR TITLE
Allowing own replication via LDAP_REPLICATION=own

### DIFF
--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -482,6 +482,13 @@ EOF
       [[ -f "$WAS_STARTED_WITH_REPLICATION" ]] && rm -f "$WAS_STARTED_WITH_REPLICATION"
       echo "export PREVIOUS_HOSTNAME=${HOSTNAME}" > $WAS_STARTED_WITH_REPLICATION
 
+    elif [ "${LDAP_REPLICATION,,}" == "own" ]; then
+
+      log-helper info "Not touching replication config..."
+
+      [[ -f "$WAS_STARTED_WITH_REPLICATION" ]] && rm -f "$WAS_STARTED_WITH_REPLICATION"
+      echo "export PREVIOUS_HOSTNAME=${HOSTNAME}" > $WAS_STARTED_WITH_REPLICATION
+
     else
 
       log-helper info "Disable replication config..."


### PR DESCRIPTION
fixes #532 by allowing to set LDAP_REPLICATION="own" to provide own replication settings via custom bootstrap ldifs.

Whether this should set WAS_STARTED_WITH_REPLICATION, or not, can be debated.