### PR TITLE
Allow LDAP_ORGANISATION env var to be used in LDIF files

### DIFF
--- a/image/service/slapd/assets/config/bootstrap/ldif/custom/README.md
+++ b/image/service/slapd/assets/config/bootstrap/ldif/custom/README.md
@@ -6,6 +6,7 @@ The startup script provides some substitutions in bootstrap ldif files. Followin
 - `{{ LDAP_BASE_DN }}`
 - `{{ LDAP_BACKEND }}`
 - `{{ LDAP_DOMAIN }}`
+- `{{ LDAP_ORGANISATION }}`
 - `{{ LDAP_READONLY_USER_USERNAME }}`
 - `{{ LDAP_READONLY_USER_PASSWORD_ENCRYPTED }}`
 

--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -159,6 +159,7 @@ if [ ! -e "$FIRST_START_DONE" ]; then
     sed -i "s|{{ LDAP_BASE_DN }}|${LDAP_BASE_DN}|g" $LDIF_FILE
     sed -i "s|{{ LDAP_BACKEND }}|${LDAP_BACKEND}|g" $LDIF_FILE
     sed -i "s|{{ LDAP_DOMAIN }}|${LDAP_DOMAIN}|g" $LDIF_FILE
+    sed -i "s|{{ LDAP_ORGANISATION }}|${LDAP_ORGANISATION}|g" $LDIF_FILE
     if [ "${LDAP_READONLY_USER,,}" == "true" ]; then
       sed -i "s|{{ LDAP_READONLY_USER_USERNAME }}|${LDAP_READONLY_USER_USERNAME}|g" $LDIF_FILE
       sed -i "s|{{ LDAP_READONLY_USER_PASSWORD_ENCRYPTED }}|${LDAP_READONLY_USER_PASSWORD_ENCRYPTED}|g" $LDIF_FILE


### PR DESCRIPTION
Hi,

I currently had a use case, where it was helpful to be able to use the LDAP_ORGANISATION environment variable inside of a custom bootstrap LDIF file (as `sambaDomainName` in a `sambaDomain` entry).

I thought I'd push my modifications here, so other users could benefit from it if they also come across a use case for this variable.