### PR TITLE
fix: escape special chars in passwords for replication

### DIFF
--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -476,8 +476,10 @@ EOF
 
       get_ldap_base_dn
       sed -i "s|\$LDAP_BASE_DN|$LDAP_BASE_DN|g" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/replication/replication-enable.ldif
-      sed -i "s|\$LDAP_ADMIN_PASSWORD|$LDAP_ADMIN_PASSWORD|g" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/replication/replication-enable.ldif
-      sed -i "s|\$LDAP_CONFIG_PASSWORD|$LDAP_CONFIG_PASSWORD|g" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/replication/replication-enable.ldif
+      LDAP_ADMIN_PASSWORD_ESCAPED=$(echo $LDAP_ADMIN_PASSWORD | sed 's/\([&|\]\)/\\\1/g')
+      sed -i "s|\$LDAP_ADMIN_PASSWORD|$LDAP_ADMIN_PASSWORD_ESCAPED|g" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/replication/replication-enable.ldif
+      LDAP_CONFIG_PASSWORD_ESCAPED=$(echo $LDAP_CONFIG_PASSWORD | sed 's/\([&|\]\)/\\\1/g')
+      sed -i "s|\$LDAP_CONFIG_PASSWORD|$LDAP_CONFIG_PASSWORD_ESCAPED|g" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/replication/replication-enable.ldif
 
       sed -i "/{{ LDAP_REPLICATION_HOSTS }}/d" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/replication/replication-enable.ldif
       sed -i "/{{ LDAP_REPLICATION_HOSTS_CONFIG_SYNC_REPL }}/d" ${CONTAINER_SERVICE_DIR}/slapd/assets/config/replication/replication-enable.ldif


### PR DESCRIPTION
escape pipe (delimiter), ampersand (reference) and backslash (escape character) so that passwords with these characters are handled correctly

fix #464